### PR TITLE
Add React Router with Search UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,11 @@
 import React from 'react';
+import {
+  BrowserRouter as Router,
+  Route,
+  Redirect,
+  Switch,
+} from 'react-router-dom';
+
 import { Layout, message } from 'antd';
 
 import NavBar from './components/NavBar';
@@ -94,40 +101,58 @@ function App() {
   };
 
   return (
-    <div>
-      <NavBar
-        project={project}
-        cartItems={cart.length}
-        onProjectChange={(value) => handleProjectChange(value)}
-        onSearch={(text) => setTextInputs([...textInputs, text])}
-      ></NavBar>
-
-      <Layout id="body-layout" style={styles.bodyLayout}>
-        <Sider style={styles.bodySider} width={250}>
-          <Facets
-            project={project}
-            onProjectChange={(selectedProject) =>
-              handleProjectChange(selectedProject)
-            }
-            onSetFacets={(facets) => setAppliedFacets(facets)}
-          />
-        </Sider>
-        <Content style={styles.bodyContent}>
-          <Search
-            project={project}
-            textInputs={textInputs}
-            appliedFacets={appliedFacets}
-            cart={cart}
-            handleCart={handleCart}
-            onRemoveTag={(removedTag, type) =>
-              handleRemoveTag(removedTag, type)
-            }
-            onClearTags={() => clearConstraints()}
-          ></Search>
-        </Content>
-      </Layout>
-      <Footer style={styles.footer}>ESGF Search UI ©2020</Footer>
-    </div>
+    <Router>
+      <Redirect exact from="/" to="/search" />
+      <div>
+        <NavBar
+          project={project}
+          cartItems={cart.length}
+          onProjectChange={(value) => handleProjectChange(value)}
+          onSearch={(text) => setTextInputs([...textInputs, text])}
+        ></NavBar>
+        <Layout id="body-layout" style={styles.bodyLayout}>
+          <Switch>
+            <Route
+              path="/search"
+              render={() => (
+                <Sider style={styles.bodySider} width={250}>
+                  <Facets
+                    project={project}
+                    onProjectChange={(selectedProject) =>
+                      handleProjectChange(selectedProject)
+                    }
+                    onSetFacets={(facets) => setAppliedFacets(facets)}
+                  />
+                </Sider>
+              )}
+            />
+          </Switch>
+          <Content style={styles.bodyContent}>
+            <Switch>
+              <Route
+                path="/search"
+                render={() => (
+                  <Search
+                    project={project}
+                    textInputs={textInputs}
+                    appliedFacets={appliedFacets}
+                    cart={cart}
+                    handleCart={handleCart}
+                    onRemoveTag={(removedTag, type) =>
+                      handleRemoveTag(removedTag, type)
+                    }
+                    onClearTags={() => clearConstraints()}
+                  ></Search>
+                )}
+              ></Route>
+            </Switch>
+          </Content>
+        </Layout>
+        <Footer data-testid="footer" style={styles.footer}>
+          ESGF Search UI ©2020
+        </Footer>
+      </div>
+    </Router>
   );
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -117,12 +117,17 @@ function App() {
     <Router>
       <Redirect exact from="/" to="/search" />
       <div>
-        <NavBar
-          project={project}
-          cartItems={cart.length}
-          onProjectChange={(value) => handleProjectChange(value)}
-          onSearch={(input) => handleOnSearch(input)}
-        ></NavBar>
+        <Route
+          path="/"
+          render={() => (
+            <NavBar
+              project={project}
+              cartItems={cart.length}
+              onProjectChange={(value) => handleProjectChange(value)}
+              onSearch={(input) => handleOnSearch(input)}
+            ></NavBar>
+          )}
+        />
         <Layout id="body-layout" style={styles.bodyLayout}>
           <Switch>
             <Route

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -100,6 +100,19 @@ function App() {
     }
   };
 
+  /**
+   * Handles free-text search form submission.
+   *
+   * @param {string} input - free-text input to query for search results
+   */
+  const handleOnSearch = (input) => {
+    if (textInputs.includes(input)) {
+      message.error(`Input "${input}" has already been applied`);
+    } else {
+      setTextInputs([...textInputs, input]);
+    }
+  };
+
   return (
     <Router>
       <Redirect exact from="/" to="/search" />
@@ -108,7 +121,7 @@ function App() {
           project={project}
           cartItems={cart.length}
           onProjectChange={(value) => handleProjectChange(value)}
-          onSearch={(text) => setTextInputs([...textInputs, text])}
+          onSearch={(input) => handleOnSearch(input)}
         ></NavBar>
         <Layout id="body-layout" style={styles.bodyLayout}>
           <Switch>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { act, render, cleanup, wait } from '@testing-library/react';
 
 import App from './App';
@@ -6,11 +7,17 @@ import App from './App';
 // Can add to Jest config to clean up
 afterEach(cleanup);
 
-test('App renders without crashing', async () => {
+test('App renders without crashing at "/"', async () => {
   await act(async () => {
-    const { getByTestId } = render(<App />);
+    const { getByTestId } = render(
+      <Router>
+        <App />
+      </Router>
+    );
 
     expect(getByTestId('nav-bar'));
+    expect(getByTestId('footer'));
+
     await wait(() => getByTestId('facets'));
     expect(getByTestId('search'));
   });

--- a/frontend/src/components/NavBar/NavBar.test.jsx
+++ b/frontend/src/components/NavBar/NavBar.test.jsx
@@ -7,6 +7,7 @@ import LeftMenu from './LeftMenu';
 import RightMenu from './RightMenu';
 
 const defaultProps = {
+  project: 'test1',
   projects: ['test1', 'test2'],
   cartItems: 0,
   onSearch: jest.fn(),
@@ -22,14 +23,14 @@ test('LeftMenu and RightMenu components render correctly', async () => {
 });
 
 const leftMenuProps = {
+  project: 'test1',
   projects: ['test1', 'test2'],
-  text: '',
-  onFinish: jest.fn(),
-  handleChange: jest.fn(),
+  onSearch: jest.fn(),
+  onProjectChange: jest.fn(),
 };
 
 test('LeftMenu renders project list and updates', async () => {
-  // NOTE:testing ant-design's select component has been proven to be
+  // NOTE: Testing ant-design's select component has been proven to be
   // tricky. Attempting to extract the value that the user selects is not
   // straight-forward, so this project does a simple test to see if the
   // DOM node exists or not.
@@ -54,8 +55,13 @@ test('LeftMenu registers search input', async () => {
   fireEvent.click(getByRole('img'));
 });
 
+const rightMenuProps = {
+  mode: 'horizontal',
+  cartItems: 4,
+};
+
 test('RightMenu displays correct number of cartItems', () => {
-  const { getByText } = render(<RightMenu cartItems={4} />);
+  const { getByText } = render(<RightMenu {...rightMenuProps} />);
   expect(getByText('4')).toBeTruthy();
 });
 

--- a/frontend/src/components/NavBar/NavBar.test.jsx
+++ b/frontend/src/components/NavBar/NavBar.test.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { render, fireEvent, act } from '@testing-library/react';
 
 import NavBar from './index';
@@ -16,7 +17,11 @@ const defaultProps = {
 
 test('LeftMenu and RightMenu components render correctly', async () => {
   await act(async () => {
-    const { getByTestId } = render(<NavBar {...defaultProps} />);
+    const { getByTestId } = render(
+      <Router>
+        <NavBar {...defaultProps} />
+      </Router>
+    );
     expect(getByTestId('left-menu')).toBeTruthy();
     expect(getByTestId('right-menu')).toBeTruthy();
   });
@@ -34,7 +39,11 @@ test('LeftMenu renders project list and updates', async () => {
   // tricky. Attempting to extract the value that the user selects is not
   // straight-forward, so this project does a simple test to see if the
   // DOM node exists or not.
-  const { getByText, getByTestId } = render(<LeftMenu {...leftMenuProps} />);
+  const { getByText, getByTestId } = render(
+    <Router>
+      <LeftMenu {...leftMenuProps} />
+    </Router>
+  );
   expect(getByTestId('left-menu')).toBeTruthy();
   expect(getByText('Project')).toBeTruthy();
   fireEvent.click(getByTestId('project-select'));
@@ -45,7 +54,9 @@ test('LeftMenu registers search input', async () => {
   // the Search form field's value changes. It does not test calling the
   // onFinish function when the user submits the form.
   const { getByPlaceholderText, getByRole } = render(
-    <LeftMenu {...leftMenuProps} />
+    <Router>
+      <LeftMenu {...leftMenuProps} />
+    </Router>
   );
 
   const search = getByPlaceholderText('Search...');
@@ -61,7 +72,11 @@ const rightMenuProps = {
 };
 
 test('RightMenu displays correct number of cartItems', () => {
-  const { getByText } = render(<RightMenu {...rightMenuProps} />);
+  const { getByText } = render(
+    <Router>
+      <RightMenu {...rightMenuProps} />
+    </Router>
+  );
   expect(getByText('4')).toBeTruthy();
 });
 

--- a/frontend/src/components/NavBar/RightMenu.jsx
+++ b/frontend/src/components/NavBar/RightMenu.jsx
@@ -16,7 +16,7 @@ function RightMenu({ mode, cartItems }) {
 
   return (
     <div data-testid="right-menu">
-      <Menu mode={mode}>
+      <Menu defaultSelectedKeys={['search']} mode={mode}>
         <Menu.Item key="search">
           <Link to="/search">Search</Link>
         </Menu.Item>
@@ -30,7 +30,7 @@ function RightMenu({ mode, cartItems }) {
           Resources
         </Menu.Item>
         <Menu.Item key="login">
-          <Button type="link" style={{ fontStyle: 'bold' }}>
+          <Button type="primary" style={{ fontStyle: 'bold' }}>
             Log In
           </Button>
         </Menu.Item>

--- a/frontend/src/components/NavBar/RightMenu.jsx
+++ b/frontend/src/components/NavBar/RightMenu.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Menu } from 'antd';
 import { ShoppingCartOutlined } from '@ant-design/icons';
@@ -16,15 +17,15 @@ function RightMenu({ mode, cartItems }) {
   return (
     <div data-testid="right-menu">
       <Menu mode={mode}>
+        <Menu.Item key="search">
+          <Link to="/search">Search</Link>
+        </Menu.Item>
         <SubMenu title={<span className="submenu-title-wrapper">Learn</span>}>
           <Menu.ItemGroup title="Documentation">
             <Menu.Item key="guide">Guide</Menu.Item>
             <Menu.Item key="api">API</Menu.Item>
           </Menu.ItemGroup>
         </SubMenu>
-        <Menu.Item key="about" disabled>
-          About
-        </Menu.Item>
         <Menu.Item key="resources" disabled>
           Resources
         </Menu.Item>

--- a/frontend/src/components/Search/Search.test.jsx
+++ b/frontend/src/components/Search/Search.test.jsx
@@ -1,10 +1,22 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import Search from './index';
 
+const defaultProps = {
+  project: '',
+  textInputs: [],
+  appliedFacets: {},
+  cart: [],
+  onRemoveTag: jest.fn(),
+  onClearTags: jest.fn(),
+  onAddCart: jest.fn(),
+};
+
 test('renders without crashing', async () => {
-  test.todo('placeholder');
+  const { getByTestId } = render(<Search {...defaultProps} />);
+  expect(getByTestId('search')).toBeTruthy();
 });
 
 test('successfully shows results', async () => {

--- a/frontend/src/components/Search/SearchTable.jsx
+++ b/frontend/src/components/Search/SearchTable.jsx
@@ -117,6 +117,12 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
     hasData: results.length > 0,
   };
 
+  tableConfig.expandable.expandIcon.propTypes = {
+    expanded: PropTypes.bool.isRequired,
+    onExpand: PropTypes.func.isRequired,
+    record: PropTypes.objectOf(PropTypes.string).isRequired,
+  };
+
   const columns = [
     {
       title: 'Dataset Title',
@@ -125,6 +131,7 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
       width: 400,
       render: (title, record) => {
         return (
+          // eslint-disable-next-line react/prop-types
           <a href={record.url} rel="noopener noreferrer" target="_blank">
             {title}
           </a>
@@ -158,7 +165,9 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
         <span>
           <Form layout="inline">
             <Form.Item>
+              {/* eslint-disable-next-line react/prop-types */}
               <Select defaultValue={record.access[0]} style={{ width: 120 }}>
+                {/* eslint-disable-next-line react/prop-types */}
                 {record.access.map((option) => (
                   <Option key={option} value={option}>
                     {option}
@@ -187,6 +196,7 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
             {hasKey(record, 'xlink') && (
               <Button
                 type="link"
+                // eslint-disable-next-line react/prop-types
                 href={parseUrl(record.xlink[1], '|')}
                 target="_blank"
               >
@@ -196,6 +206,7 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
             {hasKey(record, 'further_info_url') && (
               <Button
                 type="link"
+                // eslint-disable-next-line react/prop-types
                 href={record.further_info_url[0]}
                 target="_blank"
               >

--- a/frontend/src/components/Search/index.jsx
+++ b/frontend/src/components/Search/index.jsx
@@ -57,8 +57,8 @@ function Search({
   };
 
   return (
-    <div data-testid="search">
-      <Row>
+    <div>
+      <Row data-testid="search">
         {!isEmpty(results) ? (
           <h4>
             {results.response.numFound} results found for {project}


### PR DESCRIPTION
This PR integrates React Router with the Search component. 

Summary of Changes
App.jsx
- Add ReactRouter - default path is  '/search'
- Add handleOnSearch to handle free-text form submission
App.test.jsx, NavBar.test.jsx
- Update to include ReactRouter -- otherwise tests have warning about rendering <Link /> components with <BrowserRouter/>
RightMenu.jsx
- Update to include '/search' Link
- Add default selected key to '/search'/
