### PR TITLE
Add Cart prototype

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -177,7 +177,13 @@ function App() {
               />
               <Route
                 path="/cart"
-                render={() => <Cart cart={cart} handleCart={handleCart} />}
+                render={() => (
+                  <Cart
+                    cart={cart}
+                    handleCart={handleCart}
+                    clearCart={() => setCart([])}
+                  />
+                )}
               />
             </Switch>
           </Content>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,7 +23,7 @@ const styles = {
     background: '#fff',
     padding: '25px 25px 25px 25px',
     marginLeft: '25px',
-    overflowY: 'scroll',
+    overflowY: 'auto',
   },
   bodyContent: { padding: '0 24px' },
   footer: { textAlign: 'center' },
@@ -152,7 +152,6 @@ function App() {
               path="/cart"
               render={() => (
                 <Sider style={styles.bodySider} width={250}>
-                  {' '}
                   <Summary numItems={cart.length} />
                 </Sider>
               )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -115,7 +115,9 @@ function App() {
 
   return (
     <Router>
-      <Redirect exact from="/" to="/search" />
+      <Switch>
+        <Redirect from="/" exact to="/search" />
+      </Switch>
       <div>
         <Route
           path="/"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import NavBar from './components/NavBar';
 import Facets from './components/Facets';
 import Search from './components/Search';
 import Cart from './components/Cart';
+import Summary from './components/Cart/Summary';
 
 import './App.css';
 
@@ -144,6 +145,15 @@ function App() {
                     }
                     onSetFacets={(facets) => setAppliedFacets(facets)}
                   />
+                </Sider>
+              )}
+            />
+            <Route
+              path="/cart"
+              render={() => (
+                <Sider style={styles.bodySider} width={250}>
+                  {' '}
+                  <Summary numItems={cart.length} />
                 </Sider>
               )}
             />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import { Layout, message } from 'antd';
 import NavBar from './components/NavBar';
 import Facets from './components/Facets';
 import Search from './components/Search';
+import Cart from './components/Cart';
 
 import './App.css';
 
@@ -164,7 +165,11 @@ function App() {
                     onClearTags={() => clearConstraints()}
                   ></Search>
                 )}
-              ></Route>
+              />
+              <Route
+                path="/cart"
+                render={() => <Cart cart={cart} handleCart={handleCart} />}
+              />
             </Switch>
           </Content>
         </Layout>

--- a/frontend/src/components/Cart/Cart.test.jsx
+++ b/frontend/src/components/Cart/Cart.test.jsx
@@ -178,6 +178,7 @@ const defaultProps = {
     },
   ],
   handleCart: jest.fn(),
+  clearCart: jest.fn(),
 };
 test('renders without crashing', async () => {
   const { getByTestId } = render(

--- a/frontend/src/components/Cart/Cart.test.jsx
+++ b/frontend/src/components/Cart/Cart.test.jsx
@@ -1,0 +1,201 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import Cart from './index';
+
+const defaultProps = {
+  // TODO: Replace with mock objects
+  cart: [
+    {
+      id:
+        'CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.zg.gn.v20190724|esgf-data.ucar.edu',
+      version: '20190724',
+      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
+      activity_drs: ['C4MIP'],
+      activity_id: ['C4MIP'],
+      cf_standard_name: ['geopotential_height'],
+      citation_url: [
+        'http://cera-www.dkrz.de/WDCC/meta/CMIP6/CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.zg.gn.v20190724.json',
+      ],
+      data_node: 'esgf-data.ucar.edu',
+      data_specs_version: ['01.00.29'],
+      dataset_id_template_: [
+        '%(mip_era)s.%(activity_drs)s.%(institution_id)s.%(source_id)s.%(experiment_id)s.%(member_id)s.%(table_id)s.%(variable_id)s.%(grid_label)s',
+      ],
+      datetime_start: '0001-01-15T12:00:00Z',
+      datetime_stop: '0150-12-15T12:00:00Z',
+      directory_format_template_: [
+        '%(root)s/%(mip_era)s/%(activity_drs)s/%(institution_id)s/%(source_id)s/%(experiment_id)s/%(member_id)s/%(table_id)s/%(variable_id)s/%(grid_label)s/%(version)s',
+      ],
+      east_degrees: 358.75,
+      experiment_id: ['1pctCO2-bgc'],
+      experiment_title: [
+        'biogeochemically-coupled version of 1 percent per year increasing CO2 experiment',
+      ],
+      frequency: ['mon'],
+      further_info_url: [
+        'https://furtherinfo.es-doc.org/CMIP6.NCAR.CESM2.1pctCO2-bgc.none.r1i1p1f1',
+      ],
+      geo: [
+        'ENVELOPE(-180.0, -1.25, 90.0, -90.0)',
+        'ENVELOPE(0.0, 180.0, 90.0, -90.0)',
+      ],
+      geo_units: ['degrees_east'],
+      grid: ['native 0.9x1.25 finite volume grid (192x288 latxlon)'],
+      grid_label: ['gn'],
+      height_bottom: 100000.0,
+      height_top: 100.0,
+      height_units: 'Pa',
+      index_node: 'esgf-node.llnl.gov',
+      instance_id:
+        'CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.zg.gn.v20190724',
+      institution_id: ['NCAR'],
+      latest: true,
+      master_id: 'CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.zg.gn',
+      member_id: ['r1i1p1f1'],
+      mip_era: ['CMIP6'],
+      model_cohort: ['Registered'],
+      nominal_resolution: ['100 km'],
+      north_degrees: 90.0,
+      number_of_aggregations: 2,
+      number_of_files: 3,
+      pid: ['hdl:21.14100/4a17ceec-9c75-3b1e-8965-414e3eff6a41'],
+      product: ['model-output'],
+      project: ['CMIP6'],
+      realm: ['atmos'],
+      replica: false,
+      size: 3467624092,
+      source_id: ['CESM2'],
+      source_type: ['AOGCM', 'BGC', 'AER'],
+      south_degrees: -90.0,
+      sub_experiment_id: ['none'],
+      table_id: ['Amon'],
+      title: 'CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.zg.gn',
+      type: 'Dataset',
+      url: [
+        'http://esgf-data.ucar.edu/thredds/catalog/esgcet/176/CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.zg.gn.v20190724.xml#CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.zg.gn.v20190724|application/xml+thredds|THREDDS',
+      ],
+      variable: ['zg'],
+      variable_id: ['zg'],
+      variable_long_name: ['Geopotential Height'],
+      variable_units: ['m'],
+      variant_label: ['r1i1p1f1'],
+      west_degrees: 0.0,
+      xlink: [
+        'http://cera-www.dkrz.de/WDCC/meta/CMIP6/CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.zg.gn.v20190724.json|Citation|citation',
+        'http://hdl.handle.net/hdl:21.14100/4a17ceec-9c75-3b1e-8965-414e3eff6a41|PID|pid',
+      ],
+      _version_: 1640152348733997056,
+      retracted: false,
+      _timestamp: '2019-07-26T19:59:29.981Z',
+      score: 1.0,
+    },
+    {
+      id:
+        'CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.va.gn.v20190724|esgf-data.ucar.edu',
+      version: '20190724',
+      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
+      activity_drs: ['C4MIP'],
+      activity_id: ['C4MIP'],
+      cf_standard_name: ['northward_wind'],
+      citation_url: [
+        'http://cera-www.dkrz.de/WDCC/meta/CMIP6/CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.va.gn.v20190724.json',
+      ],
+      data_node: 'esgf-data.ucar.edu',
+      data_specs_version: ['01.00.29'],
+      dataset_id_template_: [
+        '%(mip_era)s.%(activity_drs)s.%(institution_id)s.%(source_id)s.%(experiment_id)s.%(member_id)s.%(table_id)s.%(variable_id)s.%(grid_label)s',
+      ],
+      datetime_start: '0001-01-15T12:00:00Z',
+      datetime_stop: '0150-12-15T12:00:00Z',
+      directory_format_template_: [
+        '%(root)s/%(mip_era)s/%(activity_drs)s/%(institution_id)s/%(source_id)s/%(experiment_id)s/%(member_id)s/%(table_id)s/%(variable_id)s/%(grid_label)s/%(version)s',
+      ],
+      east_degrees: 358.75,
+      experiment_id: ['1pctCO2-bgc'],
+      experiment_title: [
+        'biogeochemically-coupled version of 1 percent per year increasing CO2 experiment',
+      ],
+      frequency: ['mon'],
+      further_info_url: [
+        'https://furtherinfo.es-doc.org/CMIP6.NCAR.CESM2.1pctCO2-bgc.none.r1i1p1f1',
+      ],
+      geo: [
+        'ENVELOPE(-180.0, -1.25, 90.0, -90.0)',
+        'ENVELOPE(0.0, 180.0, 90.0, -90.0)',
+      ],
+      geo_units: ['degrees_east'],
+      grid: ['native 0.9x1.25 finite volume grid (192x288 latxlon)'],
+      grid_label: ['gn'],
+      height_bottom: 100000.0,
+      height_top: 100.0,
+      height_units: 'Pa',
+      index_node: 'esgf-node.llnl.gov',
+      instance_id:
+        'CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.va.gn.v20190724',
+      institution_id: ['NCAR'],
+      latest: true,
+      master_id: 'CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.va.gn',
+      member_id: ['r1i1p1f1'],
+      mip_era: ['CMIP6'],
+      model_cohort: ['Registered'],
+      nominal_resolution: ['100 km'],
+      north_degrees: 90.0,
+      number_of_aggregations: 2,
+      number_of_files: 3,
+      pid: ['hdl:21.14100/c0645bfd-8e9a-3fcb-8de0-9d518df732a5'],
+      product: ['model-output'],
+      project: ['CMIP6'],
+      realm: ['atmos'],
+      replica: false,
+      size: 5633327855,
+      source_id: ['CESM2'],
+      source_type: ['AOGCM', 'BGC', 'AER'],
+      south_degrees: -90.0,
+      sub_experiment_id: ['none'],
+      table_id: ['Amon'],
+      title: 'CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.va.gn',
+      type: 'Dataset',
+      url: [
+        'http://esgf-data.ucar.edu/thredds/catalog/esgcet/176/CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.va.gn.v20190724.xml#CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.va.gn.v20190724|application/xml+thredds|THREDDS',
+      ],
+      variable: ['va'],
+      variable_id: ['va'],
+      variable_long_name: ['Northward Wind'],
+      variable_units: ['m s-1'],
+      variant_label: ['r1i1p1f1'],
+      west_degrees: 0.0,
+      xlink: [
+        'http://cera-www.dkrz.de/WDCC/meta/CMIP6/CMIP6.C4MIP.NCAR.CESM2.1pctCO2-bgc.r1i1p1f1.Amon.va.gn.v20190724.json|Citation|citation',
+        'http://hdl.handle.net/hdl:21.14100/c0645bfd-8e9a-3fcb-8de0-9d518df732a5|PID|pid',
+      ],
+      _version_: 1640152339436273664,
+      retracted: false,
+      _timestamp: '2019-07-26T19:59:21.114Z',
+      score: 1.0,
+    },
+  ],
+  handleCart: jest.fn(),
+};
+test('renders without crashing', async () => {
+  const { getByTestId } = render(
+    <Router>
+      <Cart {...defaultProps} />
+    </Router>
+  );
+  expect(getByTestId('cart')).toBeTruthy();
+});
+
+test('renders items in the cart', async () => {
+  test.todo('placeholder');
+});
+
+test('clicking remove button removes item', async () => {
+  test.todo('placeholder');
+});
+
+test('clicking add button adds item', async () => {
+  test.todo('placeholder');
+});

--- a/frontend/src/components/Cart/Summary.jsx
+++ b/frontend/src/components/Cart/Summary.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Divider, Form, Select } from 'antd';
+import { DownloadOutlined, ShoppingCartOutlined } from '@ant-design/icons';
+
+import Button from '../General/Button';
+
+const { Option } = Select;
+
+function Summary({ numItems }) {
+  Summary.propTypes = {
+    numItems: PropTypes.number,
+  };
+  Summary.defaultProps = {
+    numItems: 0,
+  };
+  const [form] = Form.useForm();
+  const downloadOptions = ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'];
+
+  /**
+   * Handles when the user selects to download their cart
+   * TODO: Implement function
+   * @param {*} values
+   */
+  const handleOnFinish = (values) => {
+    console.log(values);
+  };
+
+  return (
+    <div data-testid="summary">
+      <ShoppingCartOutlined style={{ fontSize: '4rem' }} />
+      <h1>Data Cart Summary</h1>
+      <Divider />
+      <h1>
+        Number of Files: <span style={{ float: 'right' }}>{numItems}</span>
+      </h1>
+      <h1>
+        Total File Size: <span style={{ float: 'right' }}>N/A</span>
+      </h1>
+      <Divider />
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={(values) => handleOnFinish(values)}
+      >
+        <Form.Item name="download">
+          <Select defaultValue={downloadOptions[0]} style={{ width: 120 }}>
+            {/* eslint-disable-next-line react/prop-types */}
+            {downloadOptions.map((option) => (
+              <Option key={option} value={option}>
+                {option}
+              </Option>
+            ))}
+            /
+          </Select>
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" htmlType="submit" icon={<DownloadOutlined />}>
+            Download
+          </Button>
+        </Form.Item>
+      </Form>
+    </div>
+  );
+}
+
+export default Summary;

--- a/frontend/src/components/Cart/Summary.jsx
+++ b/frontend/src/components/Cart/Summary.jsx
@@ -8,12 +8,6 @@ import Button from '../General/Button';
 const { Option } = Select;
 
 function Summary({ numItems }) {
-  Summary.propTypes = {
-    numItems: PropTypes.number,
-  };
-  Summary.defaultProps = {
-    numItems: 0,
-  };
   const [form] = Form.useForm();
   const downloadOptions = ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'];
 
@@ -23,7 +17,7 @@ function Summary({ numItems }) {
    * @param {*} values
    */
   const handleOnFinish = (values) => {
-    console.log(values);
+    return values;
   };
 
   return (
@@ -66,5 +60,13 @@ function Summary({ numItems }) {
     </div>
   );
 }
+
+Summary.propTypes = {
+  numItems: PropTypes.number,
+};
+
+Summary.defaultProps = {
+  numItems: 0,
+};
 
 export default Summary;

--- a/frontend/src/components/Cart/Summary.jsx
+++ b/frontend/src/components/Cart/Summary.jsx
@@ -42,9 +42,12 @@ function Summary({ numItems }) {
         form={form}
         layout="vertical"
         onFinish={(values) => handleOnFinish(values)}
+        initialValues={{
+          download: downloadOptions[0],
+        }}
       >
         <Form.Item name="download">
-          <Select defaultValue={downloadOptions[0]} style={{ width: 120 }}>
+          <Select style={{ width: 120 }}>
             {/* eslint-disable-next-line react/prop-types */}
             {downloadOptions.map((option) => (
               <Option key={option} value={option}>

--- a/frontend/src/components/Cart/Summary.test.jsx
+++ b/frontend/src/components/Cart/Summary.test.jsx
@@ -1,0 +1,19 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import Summary from './Summary';
+
+const defaultProps = {
+  numItems: 5,
+};
+
+test('renders without crashing', () => {
+  const { getByTestId } = render(
+    <Router>
+      <Summary {...defaultProps} />
+    </Router>
+  );
+  expect(getByTestId('summary')).toBeTruthy();
+});

--- a/frontend/src/components/Cart/index.jsx
+++ b/frontend/src/components/Cart/index.jsx
@@ -3,15 +3,43 @@ import PropTypes from 'prop-types';
 import { Col, Row } from 'antd';
 
 import SearchTable from '../Search/SearchTable';
+import Alert from '../Feedback/Alert';
+import Button from '../General/Button';
 
-function Cart({ cart, handleCart }) {
+const styles = {
+  summary: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginTop: 10,
+    marginBottom: 10,
+    leftSide: {
+      display: 'flex',
+    },
+  },
+};
+function Cart({ cart, handleCart, clearCart }) {
   Cart.propTypes = {
     cart: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
     handleCart: PropTypes.func.isRequired,
+    clearCart: PropTypes.func.isRequired,
   };
 
   return (
     <div data-testid="cart">
+      <div style={styles.summary}>
+        <div style={styles.summary.leftSide}>
+          {cart.length === 0 && (
+            <Alert message="Your cart is empty" type="info" showIcon />
+          )}
+        </div>
+        <div>
+          {cart.length > 0 && (
+            <Button type="danger" onClick={() => clearCart()}>
+              Remove All Items
+            </Button>
+          )}
+        </div>
+      </div>
       <Row gutter={[24, 16]} justify="space-around">
         <Col lg={24}>
           <SearchTable

--- a/frontend/src/components/Cart/index.jsx
+++ b/frontend/src/components/Cart/index.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Col, Row } from 'antd';
+
+import SearchTable from '../Search/SearchTable';
+
+function Cart({ cart, handleCart }) {
+  Cart.propTypes = {
+    cart: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
+    handleCart: PropTypes.func.isRequired,
+  };
+
+  return (
+    <div data-testid="cart">
+      <Row gutter={[24, 16]} justify="space-around">
+        <Col lg={24}>
+          <SearchTable
+            loading={false}
+            results={cart}
+            cart={cart}
+            handleCart={handleCart}
+          />
+        </Col>
+      </Row>
+    </div>
+  );
+}
+
+export default Cart;

--- a/frontend/src/components/Cart/index.jsx
+++ b/frontend/src/components/Cart/index.jsx
@@ -20,12 +20,6 @@ const styles = {
   },
 };
 function Cart({ cart, handleCart, clearCart }) {
-  Cart.propTypes = {
-    cart: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
-    handleCart: PropTypes.func.isRequired,
-    clearCart: PropTypes.func.isRequired,
-  };
-
   return (
     <div data-testid="cart">
       <div style={styles.summary}>
@@ -58,5 +52,11 @@ function Cart({ cart, handleCart, clearCart }) {
     </div>
   );
 }
+
+Cart.propTypes = {
+  cart: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
+  handleCart: PropTypes.func.isRequired,
+  clearCart: PropTypes.func.isRequired,
+};
 
 export default Cart;

--- a/frontend/src/components/Cart/index.jsx
+++ b/frontend/src/components/Cart/index.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, Row } from 'antd';
+import { QuestionCircleOutlined } from '@ant-design/icons';
 
 import SearchTable from '../Search/SearchTable';
 import Alert from '../Feedback/Alert';
 import Button from '../General/Button';
+import Popconfirm from '../Feedback/Popconfirm';
 
 const styles = {
   summary: {
@@ -34,9 +36,12 @@ function Cart({ cart, handleCart, clearCart }) {
         </div>
         <div>
           {cart.length > 0 && (
-            <Button type="danger" onClick={() => clearCart()}>
-              Remove All Items
-            </Button>
+            <Popconfirm
+              icon={<QuestionCircleOutlined style={{ color: 'red' }} />}
+              onConfirm={() => clearCart()}
+            >
+              <Button type="danger">Remove All Items</Button>
+            </Popconfirm>
           )}
         </div>
       </div>

--- a/frontend/src/components/Facets/index.jsx
+++ b/frontend/src/components/Facets/index.jsx
@@ -18,12 +18,6 @@ const styles = {
 };
 
 function Facets({ project, onProjectChange, onSetFacets }) {
-  Facets.propTypes = {
-    project: PropTypes.string.isRequired,
-    onProjectChange: PropTypes.func.isRequired,
-    onSetFacets: PropTypes.func.isRequired,
-  };
-
   const [form] = Form.useForm();
   const [selectedProject, setSelectedProject] = React.useState('');
   const [parsedFacets, setParsedFacets] = React.useState([]);
@@ -174,5 +168,11 @@ function Facets({ project, onProjectChange, onSetFacets }) {
     </div>
   );
 }
+
+Facets.propTypes = {
+  project: PropTypes.string.isRequired,
+  onProjectChange: PropTypes.func.isRequired,
+  onSetFacets: PropTypes.func.isRequired,
+};
 
 export default Facets;

--- a/frontend/src/components/Feedback/Alert.jsx
+++ b/frontend/src/components/Feedback/Alert.jsx
@@ -3,18 +3,6 @@ import PropTypes from 'prop-types';
 import { Alert as AlertD } from 'antd';
 
 function Alert({ message, description, type, showIcon }) {
-  Alert.propTypes = {
-    message: PropTypes.string.isRequired,
-    description: PropTypes.string,
-    type: PropTypes.string.isRequired,
-    showIcon: PropTypes.bool,
-  };
-
-  Alert.defaultProps = {
-    description: null,
-    showIcon: true,
-  };
-
   return (
     <AlertD
       message={message}
@@ -25,4 +13,15 @@ function Alert({ message, description, type, showIcon }) {
   );
 }
 
+Alert.propTypes = {
+  message: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  type: PropTypes.string.isRequired,
+  showIcon: PropTypes.bool,
+};
+
+Alert.defaultProps = {
+  description: null,
+  showIcon: true,
+};
 export default Alert;

--- a/frontend/src/components/Feedback/Popconfirm.jsx
+++ b/frontend/src/components/Feedback/Popconfirm.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Popconfirm as PopconfirmD } from 'antd';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
+
+function Popconfirm({ title, icon, onConfirm, children }) {
+  return (
+    <PopconfirmD title={title} icon={icon} onConfirm={onConfirm}>
+      {children}
+    </PopconfirmD>
+  );
+}
+
+Popconfirm.propTypes = {
+  title: PropTypes.string,
+  icon: PropTypes.elementType,
+  onConfirm: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+Popconfirm.defaultProps = {
+  title: 'Are you sure?',
+  icon: <ExclamationCircleOutlined />,
+};
+
+export default Popconfirm;

--- a/frontend/src/components/General/Button.jsx
+++ b/frontend/src/components/General/Button.jsx
@@ -12,27 +12,6 @@ function Button({
   onClick,
   children,
 }) {
-  Button.propTypes = {
-    type: PropTypes.string.isRequired,
-    className: PropTypes.string,
-    href: PropTypes.string,
-    target: PropTypes.string,
-    icon: PropTypes.node,
-    htmlType: PropTypes.string,
-    onClick: PropTypes.func,
-    children: PropTypes.node,
-  };
-
-  Button.defaultProps = {
-    className: undefined,
-    href: undefined,
-    target: undefined,
-    icon: undefined,
-    htmlType: undefined,
-    onClick: undefined,
-    children: undefined,
-  };
-
   return (
     <ButtonD
       type={type}
@@ -48,4 +27,24 @@ function Button({
   );
 }
 
+Button.propTypes = {
+  type: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  href: PropTypes.string,
+  target: PropTypes.string,
+  icon: PropTypes.node,
+  htmlType: PropTypes.string,
+  onClick: PropTypes.func,
+  children: PropTypes.node,
+};
+
+Button.defaultProps = {
+  className: undefined,
+  href: undefined,
+  target: undefined,
+  icon: undefined,
+  htmlType: undefined,
+  onClick: undefined,
+  children: undefined,
+};
 export default Button;

--- a/frontend/src/components/General/Tag.jsx
+++ b/frontend/src/components/General/Tag.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { Tag as TagD } from 'antd';
 import PropTypes from 'prop-types';
 
+const styles = {
+  tag: { height: '2em' },
+};
+
 function Tag({ input, onClose, closable }) {
   Tag.propTypes = {
     input: PropTypes.oneOfType([
@@ -19,7 +23,7 @@ function Tag({ input, onClose, closable }) {
   };
 
   return (
-    <TagD closable={closable} onClose={() => onClose(input)}>
+    <TagD style={styles.tag} closable={closable} onClose={() => onClose(input)}>
       {input.constructor === Array ? input[0] : input}
     </TagD>
   );

--- a/frontend/src/components/General/ToolTip.jsx
+++ b/frontend/src/components/General/ToolTip.jsx
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import { Tooltip as TooltipD } from 'antd';
 
 function ToolTip({ title }) {
-  ToolTip.propTypes = {
-    title: PropTypes.string.isRequired,
-  };
   return <TooltipD title={title}></TooltipD>;
 }
+
+ToolTip.propTypes = {
+  title: PropTypes.string.isRequired,
+};
 
 export default ToolTip;

--- a/frontend/src/components/General/ToolTip.jsx
+++ b/frontend/src/components/General/ToolTip.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip as TooltipD } from 'antd';
+
+function ToolTip({ title }) {
+  ToolTip.propTypes = {
+    title: PropTypes.string.isRequired,
+  };
+  return <TooltipD title={title}></TooltipD>;
+}
+
+export default ToolTip;

--- a/frontend/src/components/NavBar/LeftMenu.jsx
+++ b/frontend/src/components/NavBar/LeftMenu.jsx
@@ -10,13 +10,6 @@ const styles = {
   searchForm: { marginTop: '1em' },
 };
 function LeftMenu({ project, projects, onSearch, onProjectChange }) {
-  LeftMenu.propTypes = {
-    project: PropTypes.string.isRequired,
-    projects: PropTypes.arrayOf(PropTypes.string).isRequired,
-    onSearch: PropTypes.func.isRequired,
-    onProjectChange: PropTypes.func.isRequired,
-  };
-
   const [form] = Form.useForm();
   const [text, setText] = React.useState('');
 
@@ -77,5 +70,12 @@ function LeftMenu({ project, projects, onSearch, onProjectChange }) {
     </div>
   );
 }
+
+LeftMenu.propTypes = {
+  project: PropTypes.string.isRequired,
+  projects: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onSearch: PropTypes.func.isRequired,
+  onProjectChange: PropTypes.func.isRequired,
+};
 
 export default LeftMenu;

--- a/frontend/src/components/NavBar/LeftMenu.jsx
+++ b/frontend/src/components/NavBar/LeftMenu.jsx
@@ -6,7 +6,9 @@ import { SearchOutlined } from '@ant-design/icons';
 import Button from '../General/Button';
 
 const { Option } = Select;
-
+const styles = {
+  searchForm: { marginTop: '1em' },
+};
 function LeftMenu({ project, projects, onSearch, onProjectChange }) {
   LeftMenu.propTypes = {
     project: PropTypes.string.isRequired,
@@ -36,7 +38,7 @@ function LeftMenu({ project, projects, onSearch, onProjectChange }) {
 
   return (
     <div data-testid="left-menu">
-      <Form form={form} onFinish={onFinish}>
+      <Form style={styles.searchForm} form={form} onFinish={onFinish}>
         <Input.Group compact>
           <Form.Item
             name="project"

--- a/frontend/src/components/NavBar/NavBar.css
+++ b/frontend/src/components/NavBar/NavBar.css
@@ -26,7 +26,6 @@
 }
 
 .navbar-container .navbar-right {
-  align-self: flex-end;
   width: 30%;
 }
 

--- a/frontend/src/components/NavBar/RightMenu.jsx
+++ b/frontend/src/components/NavBar/RightMenu.jsx
@@ -35,10 +35,12 @@ function RightMenu({ mode, cartItems }) {
           </Button>
         </Menu.Item>
         <Menu.Item>
-          <Button type="link">
-            <ShoppingCartOutlined style={{ fontSize: '24px' }} />
-            {cartItems}
-          </Button>
+          <Link to="/cart">
+            <Button type="link">
+              <ShoppingCartOutlined style={{ fontSize: '24px' }} />
+              {cartItems}
+            </Button>
+          </Link>
         </Menu.Item>
       </Menu>
     </div>

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { useAsync } from 'react-async';
 import PropTypes from 'prop-types';
 import { Drawer } from 'antd';
@@ -27,13 +28,15 @@ function NavBar({ project, cartItems, onSearch, onProjectChange }) {
   return (
     <nav data-testid="nav-bar" className="navbar">
       <div className="navbar-logo">
-        <Button type="link" href="#">
-          <img
-            style={{ maxWidth: '100%', height: 'auto' }}
-            src={esgfLogo}
-            alt="ESGF Logo"
-          />
-        </Button>
+        <Link to="/search">
+          <Button type="link" href="#">
+            <img
+              style={{ maxWidth: '100%', height: 'auto' }}
+              src={esgfLogo}
+              alt="ESGF Logo"
+            />
+          </Button>
+        </Link>
       </div>
 
       <div className="navbar-container">

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -29,13 +29,11 @@ function NavBar({ project, cartItems, onSearch, onProjectChange }) {
     <nav data-testid="nav-bar" className="navbar">
       <div className="navbar-logo">
         <Link to="/search">
-          <Button type="link" href="#">
-            <img
-              style={{ maxWidth: '100%', height: 'auto' }}
-              src={esgfLogo}
-              alt="ESGF Logo"
-            />
-          </Button>
+          <img
+            style={{ maxWidth: '100%', height: 'auto' }}
+            src={esgfLogo}
+            alt="ESGF Logo"
+          />
         </Link>
       </div>
 

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -15,13 +15,6 @@ import { fetchProjects } from '../../utils/api';
 import esgfLogo from '../../assets/img/esgf_logo.png';
 
 function NavBar({ project, cartItems, onSearch, onProjectChange }) {
-  NavBar.propTypes = {
-    project: PropTypes.string.isRequired,
-    cartItems: PropTypes.number.isRequired,
-    onSearch: PropTypes.func.isRequired,
-    onProjectChange: PropTypes.func.isRequired,
-  };
-
   const { data, error, isPending } = useAsync({ promiseFn: fetchProjects });
   const [showDrawer, setShowDrawer] = React.useState(false);
 
@@ -77,5 +70,12 @@ function NavBar({ project, cartItems, onSearch, onProjectChange }) {
     </nav>
   );
 }
+
+NavBar.propTypes = {
+  project: PropTypes.string.isRequired,
+  cartItems: PropTypes.number.isRequired,
+  onSearch: PropTypes.func.isRequired,
+  onProjectChange: PropTypes.func.isRequired,
+};
 
 export default NavBar;

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAsync } from 'react-async';
 import PropTypes from 'prop-types';
-import { Row, Drawer } from 'antd';
+import { Drawer } from 'antd';
 import { MenuUnfoldOutlined } from '@ant-design/icons';
 
 import Alert from '../Feedback/Alert';
@@ -25,57 +25,55 @@ function NavBar({ project, cartItems, onSearch, onProjectChange }) {
   const [showDrawer, setShowDrawer] = React.useState(false);
 
   return (
-    <Row align="middle">
-      <nav data-testid="nav-bar" className="navbar">
-        <div className="navbar-logo">
-          <Button type="link" href="#">
-            <img
-              style={{ maxWidth: '100%', height: 'auto' }}
-              src={esgfLogo}
-              alt="ESGF Logo"
+    <nav data-testid="nav-bar" className="navbar">
+      <div className="navbar-logo">
+        <Button type="link" href="#">
+          <img
+            style={{ maxWidth: '100%', height: 'auto' }}
+            src={esgfLogo}
+            alt="ESGF Logo"
+          />
+        </Button>
+      </div>
+
+      <div className="navbar-container">
+        <div className="navbar-left">
+          {error ? (
+            <Alert
+              message="There was an error fetching list of projects. Please contain support or try again later."
+              type="error"
             />
-          </Button>
+          ) : (
+            <LeftMenu
+              project={project}
+              projects={isPending ? [] : data.projects}
+              onSearch={onSearch}
+              onProjectChange={onProjectChange}
+            ></LeftMenu>
+          )}
         </div>
 
-        <div className="navbar-container">
-          <div className="navbar-left">
-            {error ? (
-              <Alert
-                message="There was an error fetching list of projects. Please contain support or try again later."
-                type="error"
-              />
-            ) : (
-              <LeftMenu
-                project={project}
-                projects={isPending ? [] : data.projects}
-                onSearch={onSearch}
-                onProjectChange={onProjectChange}
-              ></LeftMenu>
-            )}
-          </div>
-
-          <div className="navbar-right">
-            <RightMenu mode="horizontal" cartItems={cartItems}></RightMenu>
-          </div>
-          <Button
-            className="navbar-mobile-button"
-            type="primary"
-            onClick={() => setShowDrawer(true)}
-          >
-            <MenuUnfoldOutlined />
-          </Button>
-          <Drawer
-            placement="right"
-            className="navbar-drawer"
-            closable={false}
-            onClose={() => setShowDrawer(false)}
-            visible={showDrawer}
-          >
-            <RightMenu mode="inline" cartItems={cartItems}></RightMenu>
-          </Drawer>
+        <div className="navbar-right">
+          <RightMenu mode="horizontal" cartItems={cartItems}></RightMenu>
         </div>
-      </nav>
-    </Row>
+        <Button
+          className="navbar-mobile-button"
+          type="primary"
+          onClick={() => setShowDrawer(true)}
+        >
+          <MenuUnfoldOutlined />
+        </Button>
+        <Drawer
+          placement="right"
+          className="navbar-drawer"
+          closable={false}
+          onClose={() => setShowDrawer(false)}
+          visible={showDrawer}
+        >
+          <RightMenu mode="inline" cartItems={cartItems}></RightMenu>
+        </Drawer>
+      </div>
+    </nav>
   );
 }
 

--- a/frontend/src/components/Search/SearchTable.jsx
+++ b/frontend/src/components/Search/SearchTable.jsx
@@ -40,7 +40,11 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     cart: PropTypes.arrayOf(PropTypes.object).isRequired,
     handleCart: PropTypes.func.isRequired,
-    onSelect: PropTypes.func.isRequired,
+    onSelect: PropTypes.func,
+  };
+
+  SearchTable.defaultProps = {
+    onSelect: undefined,
   };
 
   // Table Component configuration

--- a/frontend/src/components/Search/index.jsx
+++ b/frontend/src/components/Search/index.jsx
@@ -31,17 +31,6 @@ function Search({
   onClearTags,
   handleCart,
 }) {
-  Search.propTypes = {
-    project: PropTypes.string.isRequired,
-    textInputs: PropTypes.arrayOf(PropTypes.string).isRequired,
-    appliedFacets: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.any))
-      .isRequired,
-    cart: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
-    onRemoveTag: PropTypes.func.isRequired,
-    onClearTags: PropTypes.func.isRequired,
-    handleCart: PropTypes.func.isRequired,
-  };
-
   const { data: results, error, isLoading, run } = useAsync({
     deferFn: fetchResults,
     project,
@@ -136,5 +125,16 @@ function Search({
     </div>
   );
 }
+
+Search.propTypes = {
+  project: PropTypes.string.isRequired,
+  textInputs: PropTypes.arrayOf(PropTypes.string).isRequired,
+  appliedFacets: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.any))
+    .isRequired,
+  cart: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
+  onRemoveTag: PropTypes.func.isRequired,
+  onClearTags: PropTypes.func.isRequired,
+  handleCart: PropTypes.func.isRequired,
+};
 
 export default Search;

--- a/frontend/src/components/Search/index.jsx
+++ b/frontend/src/components/Search/index.jsx
@@ -10,7 +10,17 @@ import Tag from '../General/Tag';
 import { fetchResults } from '../../utils/api';
 import { isEmpty } from '../../utils/utils';
 
-const styles = { addButton: { marginTop: 10, marginBottom: 10 } };
+const styles = {
+  summary: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginTop: 10,
+    marginBottom: 10,
+    leftSide: {
+      display: 'flex',
+    },
+  },
+};
 
 function Search({
   project,
@@ -57,26 +67,38 @@ function Search({
   };
 
   return (
-    <div>
-      <Row data-testid="search">
-        {!isEmpty(results) ? (
-          <h4>
-            {results.response.numFound} results found for {project}
-          </h4>
-        ) : (
-          <Alert
-            message="Search for a project to display results"
-            type="info"
-            showIcon
-          />
-        )}
-      </Row>
-
+    <div data-testid="search">
+      <div style={styles.summary}>
+        <div style={styles.summary.leftSide}>
+          {!isEmpty(results) ? (
+            <h4>
+              {results.response.numFound} results found for {project}
+            </h4>
+          ) : (
+            <Alert
+              message="Search for a project to display results"
+              type="info"
+              showIcon
+            />
+          )}
+        </div>
+        <div>
+          {results && results.response.numFound > 0 && (
+            <Button
+              style={styles.addButton}
+              onClick={() => handleCart(selectedItems, 'add')}
+            >
+              Add Selected to Cart
+            </Button>
+          )}
+        </div>
+      </div>
       <Row>
-        {!isEmpty(appliedFacets) || textInputs.length > 0 ? (
-          <h4>Applied Constraints: </h4>
-        ) : (
+        {isEmpty(appliedFacets) && textInputs.length === 0 && (
           <Alert message="No constraints applied" type="info" showIcon />
+        )}
+        {(!isEmpty(appliedFacets) || textInputs.length > 0) && (
+          <h4 style={{ marginRight: '0.5em' }}>Applied Constraints: </h4>
         )}
 
         {Object.keys(appliedFacets).length !== 0 &&
@@ -97,15 +119,6 @@ function Search({
             </Button>
           ))}
       </Row>
-
-      {results && results.response.numFound > 0 && (
-        <Button
-          style={styles.addButton}
-          onClick={() => handleCart(selectedItems, 'add')}
-        >
-          Add Selected to Cart
-        </Button>
-      )}
 
       <Row gutter={[24, 16]} justify="space-around">
         <Col lg={24}>


### PR DESCRIPTION
This PR includes the addition of a prototype data cart.

Summary of Changes
App.jsx
- Add Cart Route and render Cart component
- Add default redirect to '/search' using react-router Redirect

Cart.jsx
- Displays the user's Cart, which are items added from the Search component. It re-uses the SearchTable component to display results
- Baseline tests are included in Cart.jsx.test

Summary.jsx
- New component that includes the summary of the data cart, including the number of items, size (WIP), and ability to download (WIP)
- Baseline tests are included in Summary.jsx.test

Rest of the changes
- Move .propTypes and .defaultProps below function declaration. This was done because .defaultProps doesn't work since it doesn't get set for each instance of the function.
