### PR TITLE
Re-integrate GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+backend:
+    only:
+      changes:
+        - backend/*
+    trigger:
+      include: backend/.gitlab-ci.yml
+      strategy: depend
+
+  frontend:
+    only:
+      changes:
+        - frontend/*
+    trigger:
+      include: frontend/.gitlab-ci.yml
+      strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,15 +1,15 @@
 backend:
-    only:
-      changes:
-        - backend/*
-    trigger:
-      include: backend/.gitlab-ci.yml
-      strategy: depend
+  only:
+    changes:
+      - backend/*
+  trigger:
+    include: backend/.gitlab-ci.yml
+    strategy: depend
 
-  frontend:
-    only:
-      changes:
-        - frontend/*
-    trigger:
-      include: frontend/.gitlab-ci.yml
-      strategy: depend
+frontend:
+  only:
+    changes:
+      - frontend/*
+  trigger:
+    include: frontend/.gitlab-ci.yml
+    strategy: depend

--- a/backend/.gitlab-ci.yml
+++ b/backend/.gitlab-ci.yml
@@ -41,7 +41,7 @@ flake8:
 
 pytest:
   stage: test
-  image: python:3.8-alpine
+  image: python:3.8
   tags:
     - docker
   services:

--- a/backend/.gitlab-ci.yml
+++ b/backend/.gitlab-ci.yml
@@ -58,4 +58,4 @@ pytest:
   script:
     - pytest
   after_script:
-    - bash <(curl -s https://codecov.io/bash)
+    - codecov -t $CODECOV_TOKEN

--- a/backend/.gitlab-ci.yml
+++ b/backend/.gitlab-ci.yml
@@ -58,5 +58,6 @@ pytest:
   script:
     - pytest
   after_script:
+    - cd backend
     - source venv/bin/activate
     - codecov -t $CODECOV_TOKEN

--- a/backend/.gitlab-ci.yml
+++ b/backend/.gitlab-ci.yml
@@ -57,3 +57,5 @@ pytest:
     - pip --cache-dir=$PIP_CACHE_DIR install -r requirements/local.txt
   script:
     - pytest
+  after_script:
+    - bash <(curl -s https://codecov.io/bash)

--- a/backend/.gitlab-ci.yml
+++ b/backend/.gitlab-ci.yml
@@ -2,59 +2,58 @@ stages:
     - lint
     - test
 
-  # This folder is cached between builds
-  # http://docs.gitlab.com/ce/ci/yaml/README.html#cache
-  # https://docs.gitlab.com/ee/ci/caching/#caching-python-dependencies
-  # Change pip's cache directory to be inside the project directory since we can
-  # only cache local items.
+# This folder is cached between builds
+# http://docs.gitlab.com/ce/ci/yaml/README.html#cache
+# https://docs.gitlab.com/ee/ci/caching/#caching-python-dependencies
+# Change pip's cache directory to be inside the project directory since we can
+# only cache local items.
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/backend/.cache/pip"
+
+# Pip's cache doesn't store the python packages
+# https://pip.pypa.io/en/stable/reference/pip_install/#caching
+#
+# If you want to also cache the installed packages, you have to install
+# them in a virtualenv and cache it as well.
+cache:
+  paths:
+    - .cache/pip
+    - backend/venv
+
+variables:
+  POSTGRES_USER: "metagrid"
+  POSTGRES_PASSWORD: ""
+  POSTGRES_DB: "test_metagrid"
+  # https://gitlab.com/gitlab-org/gitlab/issues/206944
+  POSTGRES_HOST_AUTH_METHOD: trust
+
+flake8:
+  stage: lint
+  image: python:3.8-alpine
+  before_script:
+    - pip install virtualenv
+    - cd backend
+    - virtualenv venv
+    - source venv/bin/activate
+    - pip --cache-dir=$PIP_CACHE_DIR install -q flake8
+  script:
+    - flake8 --config=setup.cfg
+
+pytest:
+  stage: test
+  image: python:3.8-alpine
+  tags:
+    - docker
+  services:
+    - postgres:11
   variables:
-    PIP_CACHE_DIR: "$CI_PROJECT_DIR/backend/.cache/pip"
-
-  # Pip's cache doesn't store the python packages
-  # https://pip.pypa.io/en/stable/reference/pip_install/#caching
-  #
-  # If you want to also cache the installed packages, you have to install
-  # them in a virtualenv and cache it as well.
-  cache:
-    paths:
-      - .cache/pip
-      - backend/venv
-
-  variables:
-    POSTGRES_USER: "metagrid"
-    POSTGRES_PASSWORD: ""
-    POSTGRES_DB: "test_metagrid"
-    # https://gitlab.com/gitlab-org/gitlab/issues/206944
-    POSTGRES_HOST_AUTH_METHOD: trust
-
-  flake8:
-    stage: lint
-    image: python:3.8-alpine
-    before_script:
-      - pip install virtualenv
-      - cd backend
-      - virtualenv venv
-      - source venv/bin/activate
-      - pip --cache-dir=$PIP_CACHE_DIR install -q flake8
-    script:
-      - flake8 --config=setup.cfg
-
-  pytest:
-    stage: test
-    image: python:3.8-alpine
-    tags:
-      - docker
-    services:
-      - postgres:11
-    variables:
-      DATABASE_URL: pgsql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres/$POSTGRES_DB
-      CELERY_BROKER_URL: redis://redis:6379/0
-    before_script:
-      - pip install virtualenv
-      - cd backend
-      - virtualenv venv
-      - source venv/bin/activate
-      - pip --cache-dir=$PIP_CACHE_DIR install -r requirements/local.txt
-
-    script:
-      - pytest
+    DATABASE_URL: pgsql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres/$POSTGRES_DB
+    CELERY_BROKER_URL: redis://redis:6379/0
+  before_script:
+    - pip install virtualenv
+    - cd backend
+    - virtualenv venv
+    - source venv/bin/activate
+    - pip --cache-dir=$PIP_CACHE_DIR install -r requirements/local.txt
+  script:
+    - pytest

--- a/backend/.gitlab-ci.yml
+++ b/backend/.gitlab-ci.yml
@@ -1,0 +1,60 @@
+stages:
+    - lint
+    - test
+
+  # This folder is cached between builds
+  # http://docs.gitlab.com/ce/ci/yaml/README.html#cache
+  # https://docs.gitlab.com/ee/ci/caching/#caching-python-dependencies
+  # Change pip's cache directory to be inside the project directory since we can
+  # only cache local items.
+  variables:
+    PIP_CACHE_DIR: "$CI_PROJECT_DIR/backend/.cache/pip"
+
+  # Pip's cache doesn't store the python packages
+  # https://pip.pypa.io/en/stable/reference/pip_install/#caching
+  #
+  # If you want to also cache the installed packages, you have to install
+  # them in a virtualenv and cache it as well.
+  cache:
+    paths:
+      - .cache/pip
+      - backend/venv
+
+  variables:
+    POSTGRES_USER: "metagrid"
+    POSTGRES_PASSWORD: ""
+    POSTGRES_DB: "test_metagrid"
+    # https://gitlab.com/gitlab-org/gitlab/issues/206944
+    POSTGRES_HOST_AUTH_METHOD: trust
+
+  flake8:
+    stage: lint
+    image: python:3.8-alpine
+    before_script:
+      - pip install virtualenv
+      - cd backend
+      - virtualenv venv
+      - source venv/bin/activate
+      - pip --cache-dir=$PIP_CACHE_DIR install -q flake8
+    script:
+      - flake8 --config=setup.cfg
+
+  pytest:
+    stage: test
+    image: python:3.8-alpine
+    tags:
+      - docker
+    services:
+      - postgres:11
+    variables:
+      DATABASE_URL: pgsql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres/$POSTGRES_DB
+      CELERY_BROKER_URL: redis://redis:6379/0
+    before_script:
+      - pip install virtualenv
+      - cd backend
+      - virtualenv venv
+      - source venv/bin/activate
+      - pip --cache-dir=$PIP_CACHE_DIR install -r requirements/local.txt
+
+    script:
+      - pytest

--- a/backend/.gitlab-ci.yml
+++ b/backend/.gitlab-ci.yml
@@ -58,4 +58,5 @@ pytest:
   script:
     - pytest
   after_script:
+    - source venv/bin/activate
     - codecov -t $CODECOV_TOKEN

--- a/frontend/.gitlab-ci.yml
+++ b/frontend/.gitlab-ci.yml
@@ -1,0 +1,40 @@
+# https://hub.docker.com/r/library/node/tags/
+image: node:latest
+#This declares the pipeline stages
+stages:
+  - build
+  - test
+  - deploy
+
+# This folder is cached between builds
+# http://docs.gitlab.com/ce/ci/yaml/README.html#cache
+# Change yarns's cache directory to be inside the project directory since we can
+# only cache local items.
+variables:
+  YARN_CACHE_FOLDER: '$CI_PROJECT_DIR/.yarn'
+
+# This folder is cached between builds
+# http://docs.gitlab.com/ce/ci/yaml/README.html#cache
+# Cache modules in between jobs
+cache:
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+    - .yarn
+
+build:
+  stage: build
+  before_script:
+    - cd frontend
+    - yarn config set cache-folder $YARN_CACHE_FOLDER
+    - yarn install
+  script:
+    - yarn build
+
+test:
+  stage: test
+  before_script:
+    - cd frontend
+    - yarn config set cache-folder $YARN_CACHE_FOLDER
+    - yarn install --frozen-lockfile
+  script:
+    - yarn test-coverage

--- a/frontend/.gitlab-ci.yml
+++ b/frontend/.gitlab-ci.yml
@@ -39,4 +39,5 @@ test:
   script:
     - yarn test-coverage
   after_script:
+    - cd frontend
     - ./node_modules/.bin/codecov --token="$CODECOV_TOKEN"

--- a/frontend/.gitlab-ci.yml
+++ b/frontend/.gitlab-ci.yml
@@ -38,3 +38,5 @@ test:
     - yarn install --frozen-lockfile
   script:
     - yarn test-coverage
+  after_script:
+    - bash <(curl -s https://codecov.io/bash)

--- a/frontend/.gitlab-ci.yml
+++ b/frontend/.gitlab-ci.yml
@@ -39,4 +39,4 @@ test:
   script:
     - yarn test-coverage
   after_script:
-    - bash <(curl -s https://codecov.io/bash)
+    - ./node_modules/.bin/codecov --token="$CODECOV_TOKEN"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,18 +66,7 @@
       "!**/coverage/**",
       "!**/serviceWorker.js",
       "!**/index.js"
-    ],
-    "coverageThreshold": {
-      "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80,
-        "statements": 80
-      },
-      "./src/App.js": {
-        "lines": 100
-      }
-    }
+    ]
   },
   "lint-staged": {
     "src/**/*.+(js|jsx|ts|tsx|json)": [


### PR DESCRIPTION
This PR adds GitLab CI integration back into the repository. 

I found setting up CircleCI workflows for a mono-repo somewhat difficult and confusing. GitLab CI's configuration for workflows is fairly straightforward and configured to our needs.

CircleCI can be used later in the future if needed.