### PR TITLE
Add local Node proxy

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@types/react-dom": "^16.9.5",
     "antd": "^4.0.3",
     "axios": "^0.19.2",
+    "cors-anywhere": "^0.4.2",
     "lint-staged": "^10.1.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.12.1",

--- a/frontend/src/components/Search/SearchTable.jsx
+++ b/frontend/src/components/Search/SearchTable.jsx
@@ -260,7 +260,7 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
         columns={columns}
         dataSource={tableConfig.hasData ? results : null}
         rowKey="id"
-        scroll={{ y: 600 }}
+        scroll={{ y: 590 }}
       />
     </div>
   );

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -21,7 +21,7 @@ export const fetchProjects = async () => {
  */
 export const fetchBaseFacets = async ([baseUrl]) => {
   return axios
-    .get(`https://cors-anywhere.herokuapp.com/${baseUrl}`)
+    .get(`http://localhost:8080/${baseUrl}`)
     .then((res) => {
       return res.data;
     })
@@ -53,7 +53,7 @@ const genUrlQuery = (baseUrl, textInputs, appliedFacets) => {
     );
   }
 
-  return `https://cors-anywhere.herokuapp.com/${baseUrl.replace(
+  return `http://localhost:8080/${baseUrl.replace(
     'limit=0',
     'limit=50'
   )}&${stringifyText}&${stringifyFacets}`;
@@ -86,7 +86,7 @@ export const fetchResults = async ([baseUrl, textInputs, appliedFacets]) => {
  */
 export const fetchCitation = async (url) => {
   axios
-    .get(`https://cors-anywhere.herokuapp.com/${url}`)
+    .get(`http://localhost:8080/${url}`)
     .then((res) => {
       return res.data;
     })

--- a/frontend/src/utils/proxy.js
+++ b/frontend/src/utils/proxy.js
@@ -1,0 +1,16 @@
+const corsProxy = require('cors-anywhere');
+
+// Listen on a specific host via the HOST environment variable
+const host = process.env.HOST || '0.0.0.0';
+// Listen on a specific port via the PORT environment variable
+const port = process.env.PORT || 8080;
+
+corsProxy
+  .createServer({
+    originWhitelist: ['http://localhost:3000'],
+    requireHeader: ['origin', 'x-requested-with'],
+    removeHeaders: ['cookie', 'cookie2'],
+  })
+  .listen(port, host, () => {
+    console.log(`Running CORS Anywhere on ${host}:${port}`);
+  });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3259,6 +3259,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors-anywhere@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cors-anywhere/-/cors-anywhere-0.4.2.tgz#27a3c5fb24801bf8b63ca757b33ddf04fd34dae2"
+  integrity sha512-1BNWFkI/8Zued/YZUCOwHcXebOg7KI7X4jbo0GFiR/6hVAZRgPwH7FGOrvW2swLVCHizYOkX8Wj128YnS/NWKQ==
+  dependencies:
+    http-proxy "1.11.1"
+    proxy-from-env "0.0.1"
+
 cosmiconfig@^5.0.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -4409,6 +4417,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+eventemitter3@1.x.x:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
+  integrity sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=
+
 eventemitter3@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
@@ -5418,6 +5431,14 @@ http-proxy-middleware@0.19.1:
     is-glob "^4.0.0"
     lodash "^4.17.11"
     micromatch "^3.1.10"
+
+http-proxy@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.11.1.tgz#71df55757e802d58ea810df2244019dda05ae85d"
+  integrity sha1-cd9VdX6ALVjqgQ3yJEAZ3aBa6F0=
+  dependencies:
+    eventemitter3 "1.x.x"
+    requires-port "0.x.x"
 
 http-proxy@^1.17.0:
   version "1.18.0"
@@ -8959,6 +8980,11 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
+proxy-from-env@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-0.0.1.tgz#b27c4946e9e6d5dbadb7598a6435d3014c4cfd49"
+  integrity sha1-snxJRunm1dutt1mKZDXTAUxM/Uk=
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -9870,6 +9896,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requires-port@0.x.x:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-0.0.1.tgz#4b4414411d9df7c855995dd899a8c78a2951c16d"
+  integrity sha1-S0QUQR2d98hVmV3YmajHiilRwW0=
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds a local Node proxy using the cors-anywhere package. This allows the React app to access the ESG Search API without running into the CORS issue: **No 'Access-Control-Allow-Origin' header is present on the requested resource.**

Refer to this issue here for more information: https://acme-climate.atlassian.net/browse/CR-139?atlOrigin=eyJpIjoiZjM1MjIzZDM0ZWM5NDMxNmIzYjU2N2VjMjkyM2EyZWYiLCJwIjoiaiJ9