### PR TITLE
Add dataset file display

### DIFF
--- a/frontend/src/components/Cart/index.jsx
+++ b/frontend/src/components/Cart/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Col, Row } from 'antd';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 
-import SearchTable from '../Search/SearchTable';
+import Table from '../Search/Table';
 import Alert from '../Feedback/Alert';
 import Button from '../General/Button';
 import Popconfirm from '../Feedback/Popconfirm';
@@ -41,7 +41,7 @@ function Cart({ cart, handleCart, clearCart }) {
       </div>
       <Row gutter={[24, 16]} justify="space-around">
         <Col lg={24}>
-          <SearchTable
+          <Table
             loading={false}
             results={cart}
             cart={cart}

--- a/frontend/src/components/Facets/FacetsForm.jsx
+++ b/frontend/src/components/Facets/FacetsForm.jsx
@@ -55,7 +55,7 @@ function FacetsForm({ activeFacets, availableFacets, handleFacetsForm }) {
                 </Select>
               </Form.Item>
             );
-          })}{' '}
+          })}
         </Form>
       </div>
       {!isEmpty(availableFacets) && (

--- a/frontend/src/components/Facets/FacetsForm.jsx
+++ b/frontend/src/components/Facets/FacetsForm.jsx
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Select } from 'antd';
 import { FilterOutlined } from '@ant-design/icons';
 
-import Alert from '../Feedback/Alert';
 import Button from '../General/Button';
-import Spin from '../Feedback/Spin';
 
 import { isEmpty, humanize } from '../../utils/utils';
 
@@ -13,13 +11,7 @@ const styles = {
   facetCount: { float: 'right' },
 };
 
-function FacetsForm({
-  activeFacets,
-  availableFacets,
-  facetsError,
-  facetsIsLoading,
-  handleFacetsForm,
-}) {
+function FacetsForm({ activeFacets, availableFacets, handleFacetsForm }) {
   const [facetsForm] = Form.useForm();
 
   /**
@@ -28,21 +20,6 @@ function FacetsForm({
   React.useEffect(() => {
     facetsForm.resetFields();
   }, [facetsForm, activeFacets]);
-
-  if (facetsError) {
-    return (
-      <Alert
-        message="Error"
-        description="There was an issue fetching facets for this project. Please contact support for assistance or try again later"
-        type="error"
-        showIcon
-      />
-    );
-  }
-
-  if (facetsIsLoading) {
-    return <Spin></Spin>;
-  }
 
   return (
     <>
@@ -81,7 +58,7 @@ function FacetsForm({
           })}{' '}
         </Form>
       </div>
-      {!isEmpty(availableFacets) && !facetsIsLoading && (
+      {!isEmpty(availableFacets) && (
         <Button
           onClick={() => facetsForm.submit()}
           type="primary"
@@ -100,14 +77,10 @@ FacetsForm.propTypes = {
   availableFacets: PropTypes.objectOf(
     PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any))
   ).isRequired,
-  facetsIsLoading: PropTypes.bool,
-  facetsError: PropTypes.string,
   handleFacetsForm: PropTypes.func.isRequired,
 };
 
 FacetsForm.defaultProps = {
   activeFacets: {},
-  facetsIsLoading: undefined,
-  facetsError: undefined,
 };
 export default FacetsForm;

--- a/frontend/src/components/Facets/index.jsx
+++ b/frontend/src/components/Facets/index.jsx
@@ -6,8 +6,7 @@ import ProjectForm from './ProjectForm';
 import FacetsForm from './FacetsForm';
 import Divider from '../General/Divider';
 
-import { isEmpty } from '../../utils/utils';
-import { fetchBaseFacets, fetchProjects } from '../../utils/api';
+import { fetchProjects } from '../../utils/api';
 
 const styles = {
   form: {
@@ -20,7 +19,6 @@ function Facets({
   activeFacets,
   availableFacets,
   handleProjectChange,
-  setAvailableFacets,
   onSetActiveFacets,
 }) {
   const {
@@ -30,34 +28,6 @@ function Facets({
   } = useAsync({
     promiseFn: fetchProjects,
   });
-
-  const {
-    data: facetsFetched,
-    error: facetsError,
-    isLoading: facetsIsLoading,
-    run,
-  } = useAsync({
-    deferFn: fetchBaseFacets,
-  });
-
-  /**
-   * Fetch facets when the selectedProject changes and there are no results
-   */
-  React.useEffect(() => {
-    if (!isEmpty(activeProject)) {
-      run(activeProject.facets_url);
-    }
-  }, [run, activeProject]);
-
-  /**
-   * Parse facets UI friendly format when facetsFetched updates.
-   */
-  React.useEffect(() => {
-    if (!isEmpty(facetsFetched)) {
-      const facetFields = facetsFetched.facet_counts.facet_fields;
-      setAvailableFacets(facetFields);
-    }
-  }, [setAvailableFacets, facetsFetched]);
 
   /**
    * Handles when the facets form is submitted.
@@ -98,8 +68,6 @@ function Facets({
       <Divider />
       <FacetsForm
         availableFacets={availableFacets}
-        facetsIsLoading={facetsIsLoading}
-        facetsError={facetsError}
         handleFacetsForm={handleFacetsForm}
       />
     </div>
@@ -115,7 +83,6 @@ Facets.propTypes = {
     PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any))
   ).isRequired,
   handleProjectChange: PropTypes.func.isRequired,
-  setAvailableFacets: PropTypes.func.isRequired,
   onSetActiveFacets: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -34,7 +34,7 @@ function NavBar({ activeProject, cartItems, onSearch, onProjectChange }) {
         <div className="navbar-left">
           {error && !isLoading ? (
             <Alert
-              message="There was an error fetching list of projects. Please contain support or try again later."
+              message="There was an issue fetching list of projects. Please contact support or try again later."
               type="error"
             />
           ) : (

--- a/frontend/src/components/Search/FilesTable.jsx
+++ b/frontend/src/components/Search/FilesTable.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { useAsync } from 'react-async';
+import { PropTypes } from 'prop-types';
+import { DownloadOutlined } from '@ant-design/icons';
+
+import { Form, Select, Table as TableD } from 'antd';
+
+import Button from '../General/Button';
+
+import { fetchFiles } from '../../utils/api';
+import { parseUrl } from '../../utils/utils';
+import Alert from '../Feedback/Alert';
+
+/**
+ * Splits the string by a delimiter and pops the last string
+ */
+function genDownloadUrls(urls) {
+  const newUrls = [];
+  urls.forEach((url) => {
+    const downloadType = url.split('|').pop();
+    const downloadUrl = parseUrl(url, '|');
+    newUrls.push({ downloadType, downloadUrl });
+  });
+  return newUrls;
+}
+
+function FilesTable({ id }) {
+  const { data, error, isLoading } = useAsync({
+    promiseFn: fetchFiles,
+    id,
+  });
+
+  /**
+   * Opens the selected download url in a new tab
+   * @param {} values
+   */
+  const openDownloadUrl = ({ downloadUrl }) => {
+    return window.open(downloadUrl, '_blank');
+  };
+
+  if (error) {
+    return (
+      <Alert
+        message="Error"
+        description="There was an issue fetching files for this dataset. Please contact support for assistance or try again later."
+        type="error"
+        showIcon
+      />
+    );
+  }
+
+  if (data) {
+    const columns = [
+      {
+        title: 'File Title',
+        dataIndex: 'title',
+        size: 400,
+        key: 'title',
+      },
+      {
+        title: 'Checksum',
+        dataIndex: 'checksum',
+        key: 'checksum',
+      },
+      {
+        title: 'Size',
+        dataIndex: 'size',
+        width: 100,
+        key: 'size',
+      },
+      {
+        title: 'Download',
+        key: 'download',
+        width: 200,
+        render: (record) => {
+          const downloadUrls = genDownloadUrls(record.url);
+          return (
+            <span>
+              <Form
+                layout="inline"
+                onFinish={(values) => openDownloadUrl(values)}
+                initialValues={{ download: downloadUrls[0].downloadType }}
+              >
+                <Form.Item name="download">
+                  <Select style={{ width: 120 }}>
+                    {downloadUrls.map((option) => (
+                      <Select.Option
+                        key={option.downloadType}
+                        value={option.downloadUrl}
+                      >
+                        {option.downloadType}
+                      </Select.Option>
+                    ))}
+                  </Select>
+                </Form.Item>
+                <Form.Item>
+                  <Button
+                    type="primary"
+                    htmlType="submit"
+                    icon={<DownloadOutlined />}
+                    size={12}
+                  ></Button>
+                </Form.Item>
+              </Form>
+            </span>
+          );
+        },
+      },
+    ];
+
+    return (
+      <TableD
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        size="small"
+        loading={isLoading}
+        pagination={{ position: ['bottomCenter'], showSizeChanger: true }}
+        columns={columns}
+        dataSource={data ? data.response.docs : null}
+        rowKey="id"
+        scroll={{ y: 300 }}
+      />
+    );
+  }
+  return null;
+}
+
+FilesTable.propTypes = {
+  id: PropTypes.string.isRequired,
+};
+
+export default FilesTable;

--- a/frontend/src/components/Search/Table.jsx
+++ b/frontend/src/components/Search/Table.jsx
@@ -10,6 +10,7 @@ import {
 import PropTypes from 'prop-types';
 
 import Citation from './Citation';
+import FilesTable from './FilesTable';
 import Button from '../General/Button';
 import Divider from '../General/Divider';
 
@@ -63,9 +64,7 @@ function Table({ loading, results, cart, handleCart, onSelect }) {
                 })}
               </Collapse.Panel>
               <Collapse.Panel header="Files" key="files">
-                <pre>
-                  <Table></Table>
-                </pre>
+                <FilesTable id={record.id} />
               </Collapse.Panel>
             </Collapse>
           </>

--- a/frontend/src/components/Search/Table.jsx
+++ b/frontend/src/components/Search/Table.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AutoComplete, Collapse, Form, Select, Table } from 'antd';
+import { AutoComplete, Collapse, Form, Select, Table as TableD } from 'antd';
 import {
   RightCircleOutlined,
   DownCircleOutlined,
@@ -17,7 +17,7 @@ import { hasKey, parseUrl } from '../../utils/utils';
 
 import './Search.css';
 
-function SearchTable({ loading, results, cart, handleCart, onSelect }) {
+function Table({ loading, results, cart, handleCart, onSelect }) {
   const tableConfig = {
     size: 'small',
     loading,
@@ -220,7 +220,7 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
 
   return (
     <div>
-      <Table
+      <TableD
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...tableConfig}
         columns={columns}
@@ -232,7 +232,7 @@ function SearchTable({ loading, results, cart, handleCart, onSelect }) {
   );
 }
 
-SearchTable.propTypes = {
+Table.propTypes = {
   loading: PropTypes.bool.isRequired,
   results: PropTypes.arrayOf(PropTypes.object).isRequired,
   cart: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -240,8 +240,8 @@ SearchTable.propTypes = {
   onSelect: PropTypes.func,
 };
 
-SearchTable.defaultProps = {
+Table.defaultProps = {
   onSelect: undefined,
 };
 
-export default SearchTable;
+export default Table;

--- a/frontend/src/components/Search/index.jsx
+++ b/frontend/src/components/Search/index.jsx
@@ -3,10 +3,10 @@ import { useAsync } from 'react-async';
 import PropTypes from 'prop-types';
 import { Button, Row, Col } from 'antd';
 
-import Alert from '../Feedback/Alert';
 import Table from './Table';
-
+import Alert from '../Feedback/Alert';
 import Tag from '../General/Tag';
+
 import { fetchResults } from '../../utils/api';
 import { isEmpty } from '../../utils/utils';
 
@@ -61,13 +61,23 @@ function Search({
     setSelectedItems(selectedRows);
   };
 
+  if (error) {
+    return (
+      <Alert
+        message="There was an issue fetching search results. Please contact support or try again later."
+        type="error"
+      />
+    );
+  }
+
   return (
     <div data-testid="search">
       <div style={styles.summary}>
         <div style={styles.summary.leftSide}>
           {!isEmpty(results) ? (
             <h4>
-              {results.response.numFound} results found for {activeProject.name}
+              {results.response.numFound} results found for
+              {activeProject.name}
             </h4>
           ) : (
             <Alert

--- a/frontend/src/components/Search/index.jsx
+++ b/frontend/src/components/Search/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Button, Row, Col } from 'antd';
 
 import Alert from '../Feedback/Alert';
-import SearchTable from './SearchTable';
+import Table from './Table';
 
 import Tag from '../General/Tag';
 import { fetchResults } from '../../utils/api';
@@ -130,7 +130,7 @@ function Search({
 
       <Row gutter={[24, 16]} justify="space-around">
         <Col lg={24}>
-          <SearchTable
+          <Table
             loading={isLoading}
             results={
               results && !error && !isEmpty(activeProject)

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -79,6 +79,7 @@ export const processCitation = (citation) => {
 
   return newCitation;
 };
+
 /**
  * Fetches citation data using a dataset's citation url.
  * NOTE: Local proxy used to bypass CORS (http://localhost:8080/)
@@ -90,6 +91,23 @@ export const fetchCitation = async ({ url }) => {
     .then((res) => {
       const citation = processCitation(res.data);
       return citation;
+    })
+    .catch((error) => {
+      throw new Error(error);
+    });
+};
+
+/**
+ * Fetches files for a dataset.
+ * NOTE: Local proxy used to bypass CORS (http://localhost:8080/)
+ *  @param {string} id - ID of the dataset
+ */
+export const fetchFiles = async ({ id }) => {
+  const url = `https://esgf-node.llnl.gov/search_files/${id}//esgf-node.llnl.gov/?limit=10`;
+  return axios
+    .get(`http://localhost:8080/${url}`)
+    .then((res) => {
+      return res.data;
     })
     .catch((error) => {
       throw new Error(error);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -17,22 +17,6 @@ export const fetchProjects = async () => {
 };
 
 /**
- * Fetches base facets for a project.
- * NOTE: Local proxy used to bypass CORS (http://localhost:8080/)
- * @param {*} param0.baseUrl - Base URL for a project to fetch facets
- */
-export const fetchBaseFacets = async ([baseUrl]) => {
-  return axios
-    .get(`http://localhost:8080/${baseUrl}`)
-    .then((res) => {
-      return res.data;
-    })
-    .catch((error) => {
-      throw new Error(error);
-    });
-};
-
-/**
  * Generate a URL to perform a GET request to the ESG Search API.
  * Query string parameters use the logical OR operator, so queries are inclusive.
  * NOTE: Local proxy used to bypass CORS (http://localhost:8080/)

--- a/frontend/src/utils/api.test.js
+++ b/frontend/src/utils/api.test.js
@@ -3,7 +3,6 @@ import mockAxios from 'axios';
 import {
   fetchCitation,
   fetchProjects,
-  fetchBaseFacets,
   genUrlQuery,
   fetchResults,
   processCitation,
@@ -37,49 +36,6 @@ describe('test fetchProjects()', () => {
     );
 
     await expect(fetchProjects()).rejects.toThrow(errorMessage);
-  });
-});
-
-describe('test fetchBaseFacets()', () => {
-  it('calls axios and returns base facets', async () => {
-    const results = {
-      facet1: [
-        ['var1', 1],
-        ['var2', 2],
-      ],
-      facet2: [
-        ['var3', 1],
-        ['var4', 2],
-      ],
-    };
-    mockAxios.get.mockImplementationOnce(() =>
-      Promise.resolve({
-        data: {
-          results,
-        },
-      })
-    );
-
-    const projects = await fetchBaseFacets([
-      'https://fake-esgf-search-node.com',
-    ]);
-    expect(projects).toEqual({ results });
-    expect(mockAxios.get).toHaveBeenCalledTimes(1);
-    expect(mockAxios.get).toHaveBeenCalledWith(
-      'http://localhost:8080/https://fake-esgf-search-node.com'
-    );
-  });
-
-  it('catches and throws an error', async () => {
-    const errorMessage = 'Network Error';
-
-    mockAxios.get.mockImplementationOnce(() =>
-      Promise.reject(new Error(errorMessage))
-    );
-
-    await expect(
-      fetchBaseFacets('https://fake-esgf-search-node.com')
-    ).rejects.toThrow(errorMessage);
   });
 });
 

--- a/frontend/src/utils/api.test.js
+++ b/frontend/src/utils/api.test.js
@@ -2,6 +2,7 @@ import mockAxios from 'axios';
 
 import {
   fetchCitation,
+  fetchFiles,
   fetchProjects,
   genUrlQuery,
   fetchResults,
@@ -177,5 +178,38 @@ describe('test fetchCitation()', () => {
         url: 'http://someBaseUrl.com/?',
       })
     ).rejects.toThrow(errorMessage);
+  });
+});
+
+describe('test fetchFiles()', () => {
+  let dataset;
+  beforeEach(() => {
+    dataset = { id: 'testid' };
+  });
+
+  it('calls axios and returns files', async () => {
+    const results = ['test1', 'test2'];
+    mockAxios.get.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: {
+          results,
+        },
+      })
+    );
+    const files = await fetchFiles({ id: dataset.id });
+    expect(files).toEqual({ results });
+    expect(mockAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `http://localhost:8080/https://esgf-node.llnl.gov/search_files/${dataset.id}//esgf-node.llnl.gov/?limit=10`
+    );
+  });
+  it('catches and throws an error', async () => {
+    const errorMessage = 'Network Error';
+
+    mockAxios.get.mockImplementationOnce(() =>
+      Promise.reject(new Error(errorMessage))
+    );
+
+    await expect(fetchFiles(dataset.id)).rejects.toThrow(errorMessage);
   });
 });


### PR DESCRIPTION
This PR adds a display for files for each dataset.

**Summary of Changes**
- Add FilesTable component and fetchFiles for displaying files for each dataset in the expandable dropdown
- Remove unused fetchBaseFacets function since facet counts are fetched directly from the results object of the Search API
- Rename SearchTable to Table
- Add handle for fetching results error in Table component