### PR TITLE
Add pagination to Search table

### DIFF
--- a/frontend/src/components/Search/Table.jsx
+++ b/frontend/src/components/Search/Table.jsx
@@ -18,11 +18,24 @@ import { hasKey, parseUrl } from '../../utils/utils';
 
 import './Search.css';
 
-function Table({ loading, results, cart, handleCart, onSelect }) {
+function Table({
+  loading,
+  results,
+  totalResults,
+  cart,
+  handleCart,
+  handlePagination,
+  onSelect,
+}) {
   const tableConfig = {
     size: 'small',
     loading,
-    pagination: { position: ['bottomCenter'], showSizeChanger: true },
+    pagination: {
+      total: totalResults,
+      position: ['bottomCenter'],
+      showSizeChanger: true,
+      onChange: (page, pageSize) => handlePagination(page, pageSize),
+    },
     expandable: {
       expandedRowRender: (record) => {
         const metaData = Object.entries(record).map(([k, v]) => ({
@@ -234,8 +247,10 @@ function Table({ loading, results, cart, handleCart, onSelect }) {
 Table.propTypes = {
   loading: PropTypes.bool.isRequired,
   results: PropTypes.arrayOf(PropTypes.object).isRequired,
+  totalResults: PropTypes.number.isRequired,
   cart: PropTypes.arrayOf(PropTypes.object).isRequired,
   handleCart: PropTypes.func.isRequired,
+  handlePagination: PropTypes.func.isRequired,
   onSelect: PropTypes.func,
 };
 

--- a/frontend/src/components/Search/Table.jsx
+++ b/frontend/src/components/Search/Table.jsx
@@ -25,6 +25,7 @@ function Table({
   cart,
   handleCart,
   handlePagination,
+  handlePageSizeChange,
   onSelect,
 }) {
   const tableConfig = {
@@ -35,6 +36,7 @@ function Table({
       position: ['bottomCenter'],
       showSizeChanger: true,
       onChange: (page, pageSize) => handlePagination(page, pageSize),
+      onShowSizeChange: (_current, size) => handlePageSizeChange(size),
     },
     expandable: {
       expandedRowRender: (record) => {
@@ -251,6 +253,7 @@ Table.propTypes = {
   cart: PropTypes.arrayOf(PropTypes.object).isRequired,
   handleCart: PropTypes.func.isRequired,
   handlePagination: PropTypes.func.isRequired,
+  handlePageSizeChange: PropTypes.func.isRequired,
   onSelect: PropTypes.func,
 };
 

--- a/frontend/src/components/Search/index.jsx
+++ b/frontend/src/components/Search/index.jsx
@@ -77,6 +77,14 @@ function Search({
     setPagination({ page, pageSize });
   };
 
+  /**
+   * Handles pageSize changes and resets the current page back to the first
+   * @param {number} pageSize
+   */
+  const handlePageSizeChange = (pageSize) => {
+    setPagination({ page: 1, pageSize });
+  };
+
   if (error) {
     return (
       <Alert
@@ -169,6 +177,7 @@ function Search({
             cart={cart}
             handleCart={handleCart}
             handlePagination={handlePagination}
+            handlePageSizeChange={handlePageSizeChange}
             onSelect={handleSelect}
           />
         </Col>

--- a/frontend/src/components/Search/index.jsx
+++ b/frontend/src/components/Search/index.jsx
@@ -37,12 +37,19 @@ function Search({
     project: activeProject,
   });
   const [selectedItems, setSelectedItems] = React.useState([]);
+  const [pagination, setPagination] = React.useState({
+    page: 1,
+    pageSize: 10,
+  });
+
+  // Fetch search results
   React.useEffect(() => {
     if (!isEmpty(activeProject)) {
-      run(activeProject.facets_url, textInputs, activeFacets);
+      run(activeProject.facets_url, textInputs, activeFacets, pagination);
     }
-  }, [run, activeProject, textInputs, activeFacets]);
+  }, [run, activeProject, textInputs, activeFacets, pagination]);
 
+  // Update the available facets based on the returned results
   React.useEffect(() => {
     if (!isEmpty(results)) {
       setAvailableFacets(results.facet_counts.facet_fields);
@@ -59,6 +66,15 @@ function Search({
    */
   const handleSelect = (record, selected, selectedRows) => {
     setSelectedItems(selectedRows);
+  };
+
+  /**
+   * Handles setting the pagination options based on the Search table
+   * @param {number} page
+   * @param {number} pageSize
+   */
+  const handlePagination = (page, pageSize) => {
+    setPagination({ page, pageSize });
   };
 
   if (error) {
@@ -147,8 +163,12 @@ function Search({
                 ? results.response.docs
                 : []
             }
+            totalResults={
+              results ? results.response.numFound : pagination.pageSize
+            }
             cart={cart}
             handleCart={handleCart}
+            handlePagination={handlePagination}
             onSelect={handleSelect}
           />
         </Col>

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -45,7 +45,6 @@ export const genUrlQuery = (baseUrl, textInputs, activeFacets, pagination) => {
     .replace('offset=0', `offset=${offset}`);
 
   const url = `http://localhost:8080/${newBaseUrl}&${stringifyText}&${stringifyFacets}`;
-  console.log(url);
   return url;
 };
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -24,7 +24,7 @@ export const fetchProjects = async () => {
  * @param {arrayOf(string)} textInputs - Free-text user input
  * @param {arrayOf(objectOf(arrayOf(string)))} activeFacets - User applied facets
  */
-export const genUrlQuery = (baseUrl, textInputs, activeFacets) => {
+export const genUrlQuery = (baseUrl, textInputs, activeFacets, pagination) => {
   const stringifyFacets = queryString.stringify(activeFacets, {
     arrayFormat: 'comma',
   });
@@ -38,11 +38,15 @@ export const genUrlQuery = (baseUrl, textInputs, activeFacets) => {
       }
     );
   }
+  const offset =
+    pagination.page > 1 ? (pagination.page - 1) * pagination.pageSize : 0;
+  const newBaseUrl = baseUrl
+    .replace('limit=0', `limit=${pagination.pageSize}`)
+    .replace('offset=0', `offset=${offset}`);
 
-  return `http://localhost:8080/${baseUrl.replace(
-    'limit=0',
-    'limit=50'
-  )}&${stringifyText}&${stringifyFacets}`;
+  const url = `http://localhost:8080/${newBaseUrl}&${stringifyText}&${stringifyFacets}`;
+  console.log(url);
+  return url;
 };
 
 /**
@@ -53,8 +57,13 @@ export const genUrlQuery = (baseUrl, textInputs, activeFacets) => {
  * @param {arrayOf(objectOf(arrayOf(string)))} param0.activeFacets - User applied facets
 
  */
-export const fetchResults = async ([baseUrl, textInputs, activeFacets]) => {
-  const qString = genUrlQuery(baseUrl, textInputs, activeFacets);
+export const fetchResults = async ([
+  baseUrl,
+  textInputs,
+  activeFacets,
+  pagination,
+]) => {
+  const qString = genUrlQuery(baseUrl, textInputs, activeFacets, pagination);
   return axios
     .get(qString)
     .then((res) => {

--- a/frontend/src/utils/api.test.js
+++ b/frontend/src/utils/api.test.js
@@ -41,18 +41,39 @@ describe('test fetchProjects()', () => {
 });
 
 describe('test genUrlQuery()', () => {
-  it('returns properly formatted url', () => {
-    const baseUrl = 'http://someBaseUrl.com/?';
-    const textInputs = ['input1', 'input2'];
-    const activeFacets = {
+  let baseUrl;
+  let textInputs;
+  let activeFacets;
+  beforeEach(() => {
+    baseUrl = 'http://someBaseUrl.com/?limit=0&offset=0';
+    textInputs = ['input1', 'input2'];
+    activeFacets = {
       facet1: ['var1', 'var2'],
       facet2: ['var3', 'var4'],
     };
+  });
 
-    const url = genUrlQuery(baseUrl, textInputs, activeFacets);
+  it('returns formatted url with offset of 0 on page 1', () => {
+    const pagination = {
+      page: 1,
+      pageSize: 10,
+    };
+
+    const url = genUrlQuery(baseUrl, textInputs, activeFacets, pagination);
 
     expect(url).toEqual(
-      'http://localhost:8080/http://someBaseUrl.com/?&query=input1,input2&facet1=var1,var2&facet2=var3,var4'
+      'http://localhost:8080/http://someBaseUrl.com/?limit=10&offset=0&query=input1,input2&facet1=var1,var2&facet2=var3,var4'
+    );
+  });
+  it('returns formatted url with offset of 200 and limit of 100 on page 3', () => {
+    const pagination = {
+      page: 3,
+      pageSize: 100,
+    };
+
+    const url = genUrlQuery(baseUrl, textInputs, activeFacets, pagination);
+    expect(url).toEqual(
+      'http://localhost:8080/http://someBaseUrl.com/?limit=100&offset=200&query=input1,input2&facet1=var1,var2&facet2=var3,var4'
     );
   });
 });
@@ -62,6 +83,7 @@ describe('test fetchResults()', () => {
   let baseUrl;
   let textInputs;
   let activeFacets;
+  let pagination;
 
   beforeEach(() => {
     results = ['test1', 'test2'];
@@ -71,6 +93,7 @@ describe('test fetchResults()', () => {
       facet1: ['var1', 'var2'],
       facet2: ['var3', 'var4'],
     };
+    pagination = { page: 1, pageSize: 10 };
   });
   it('calls axios and returns results', async () => {
     mockAxios.get.mockImplementationOnce(() =>
@@ -81,7 +104,12 @@ describe('test fetchResults()', () => {
       })
     );
 
-    const projects = await fetchResults([baseUrl, textInputs, activeFacets]);
+    const projects = await fetchResults([
+      baseUrl,
+      textInputs,
+      activeFacets,
+      pagination,
+    ]);
     expect(projects).toEqual({ results });
     expect(mockAxios.get).toHaveBeenCalledTimes(1);
     expect(mockAxios.get).toHaveBeenCalledWith(
@@ -99,7 +127,12 @@ describe('test fetchResults()', () => {
       })
     );
 
-    const projects = await fetchResults([baseUrl, textInputs, activeFacets]);
+    const projects = await fetchResults([
+      baseUrl,
+      textInputs,
+      activeFacets,
+      pagination,
+    ]);
     expect(projects).toEqual({ results });
     expect(mockAxios.get).toHaveBeenCalledTimes(1);
     expect(mockAxios.get).toHaveBeenCalledWith(
@@ -114,7 +147,7 @@ describe('test fetchResults()', () => {
     );
 
     await expect(
-      fetchResults([baseUrl, textInputs, activeFacets])
+      fetchResults([baseUrl, textInputs, activeFacets, pagination])
     ).rejects.toThrow(errorMessage);
   });
 });


### PR DESCRIPTION
This PR adds pagination to the Search table and updates related tests.

Note, the Search API is slow to return response. This could because of how data-heavy the response is, and possibility in combination with using a local server proxy.