### PR TITLE
Store and retrieve cart to and from localStorage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,16 @@ const App: React.FC = () => {
   >({});
   const [textInputs, setTextInputs] = React.useState<TextInputs | []>([]);
   const [activeFacets, setActiveFacets] = React.useState<ActiveFacets | {}>({});
-  const [cart, setCart] = React.useState<Cart | []>([]);
+  const [cart, setCart] = React.useState<Cart | []>(
+    JSON.parse(localStorage.getItem('cart') || '[]')
+  );
+
+  /**
+   * Stores the cart in localStorage
+   */
+  React.useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(cart));
+  }, [cart]);
 
   /**
    * Handles clearing constraints for a selected project.


### PR DESCRIPTION
This PR adds caching the cart in the browser's localStorage, and retrieves the item whenever the browser refreshes or closes.