### PR TITLE
Update order of rules for triggering builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 backend:
   rules:
+    - if: '$CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+      when: always
     - changes:
         - backend/*
-      when: always
-    - if: '$CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
       when: always
   trigger:
     include: backend/.gitlab-ci.yml
@@ -11,10 +11,10 @@ backend:
 
 frontend:
   rules:
+    - if: '$CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
+      when: always
     - changes:
         - frontend/*
-      when: always
-    - if: '$CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "master"'
       when: always
   trigger:
     include: frontend/.gitlab-ci.yml


### PR DESCRIPTION
This PR fixes the GitLab CI configurations to trigger all builds whenever a merge request is performed with the "master" branch. This is necessary in order for codecov to generate reporting for both the frontend and backend projects.