### PR TITLE
Update isort line_length to 79

### DIFF
--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -28,7 +28,7 @@ multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
-line_length=88
+line_length=79
 
 [pycodestyle]
 max-line-length = 119


### PR DESCRIPTION
This PR updates isort's `length_length` config in `setup.cfg` to 79. This makes isort consistent and interoperable with black