### PR TITLE
Add trigger for pushing to master for all workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,6 +2,7 @@ name: Back-end CI
 
 on:
   push:
+    branches: [master]
     paths:
       - ".github/workflows/backend.yml"
       - "backend/*"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,6 +5,7 @@ name: Front-end CI
 
 on:
   push:
+    branches: [master]
     paths:
       - ".github/workflows/frontend.yml"
       - "frontend/*"


### PR DESCRIPTION
This PR fixes triggering CI builds whenever a push is made to master (specifically during merging pull requests).

This also fixes codecov only reporting for one of the workflows rather than both, causing coverage % to go up or down.