### PR TITLE
Add file size unit conversion in tables

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -37,6 +37,7 @@ beforeEach(() => {
           number_of_files: 3,
           data_node: 'node.gov',
           version: 1,
+          size: 1,
           access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
         },
         {
@@ -45,6 +46,7 @@ beforeEach(() => {
           number_of_files: 2,
           data_node: 'node.gov',
           version: 1,
+          size: 1,
           access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
         },
       ],
@@ -167,7 +169,7 @@ it('handles adding and removing items from the cart', async () => {
 
   // Check first row exists
   const firstRow = getByRole('row', {
-    name: 'right-circle 3 node.gov 1 HTTPServer download plus',
+    name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(firstRow).toBeTruthy();
 
@@ -425,7 +427,7 @@ it('displays the number of files in the cart summary and handles clearing the ca
 
   // Check first row exists
   const firstRow = getByRole('row', {
-    name: 'right-circle 3 node.gov 1 HTTPServer download plus',
+    name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(firstRow).toBeTruthy();
 
@@ -462,6 +464,8 @@ it('displays the number of files in the cart summary and handles clearing the ca
   });
   expect(clearCartBtn).toBeTruthy();
   fireEvent.click(clearCartBtn);
+
+  await waitFor(() => getByTestId('cart'));
 
   // Check confirmBtn exists in popover and click it
   const confirmBtn = await waitFor(() =>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -265,18 +265,7 @@ const App: React.FC = () => {
                   style={styles.bodySider}
                   width={styles.bodySider.width}
                 >
-                  <Summary
-                    numItems={cart.length}
-                    numFiles={
-                      cart.length > 0
-                        ? (cart as SearchResult[]).reduce(
-                            (acc: number, dataset: SearchResult) =>
-                              acc + dataset.number_of_files,
-                            0
-                          )
-                        : 0
-                    }
-                  />
+                  <Summary cart={cart} />
                 </Layout.Sider>
               )}
             />

--- a/frontend/src/components/Cart/Summary.test.tsx
+++ b/frontend/src/components/Cart/Summary.test.tsx
@@ -6,8 +6,24 @@ import { fireEvent, render } from '@testing-library/react';
 import Summary, { Props } from './Summary';
 
 const defaultProps: Props = {
-  numItems: 2,
-  numFiles: 5,
+  cart: [
+    {
+      id: 'foo',
+      url: ['foo.bar'],
+      number_of_files: 3,
+      data_node: 'node.gov',
+      version: 1,
+      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
+    },
+    {
+      id: 'bar',
+      url: ['foo.bar'],
+      number_of_files: 2,
+      data_node: 'node.gov',
+      version: 1,
+      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
+    },
+  ],
 };
 
 test('renders without crashing', () => {

--- a/frontend/src/components/Cart/Summary.tsx
+++ b/frontend/src/components/Cart/Summary.tsx
@@ -3,6 +3,7 @@ import { Divider, Form, Select } from 'antd';
 import { DownloadOutlined } from '@ant-design/icons';
 
 import Button from '../General/Button';
+import { formatBytes } from '../../utils/utils';
 
 import cartImg from '../../assets/img/cart.svg';
 import dataImg from '../../assets/img/data.svg';
@@ -19,13 +20,27 @@ const styles = {
 };
 
 export type Props = {
-  numItems: number;
-  numFiles: number;
+  cart: Cart | [];
 };
 
-const Summary: React.FC<Props> = ({ numItems, numFiles }) => {
+const Summary: React.FC<Props> = ({ cart }) => {
   const [form] = Form.useForm();
   const downloadOptions = ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'];
+
+  let numFiles = 0;
+  let totalDataSize = '0';
+  if (cart.length > 0) {
+    numFiles = (cart as SearchResult[]).reduce(
+      (acc: number, dataset: SearchResult) => acc + dataset.number_of_files,
+      0
+    );
+
+    const rawDataSize = (cart as SearchResult[]).reduce(
+      (acc: number, dataset: SearchResult) => acc + dataset.size,
+      0
+    );
+    totalDataSize = formatBytes(rawDataSize);
+  }
 
   return (
     <div data-testid="summary">
@@ -38,13 +53,13 @@ const Summary: React.FC<Props> = ({ numItems, numFiles }) => {
 
       <Divider />
       <h1>
-        Number of Datasets: <span style={styles.statistic}>{numItems}</span>
+        Number of Datasets: <span style={styles.statistic}>{cart.length}</span>
       </h1>
       <h1>
         Number of Files: <span style={styles.statistic}>{numFiles}</span>
       </h1>
       <h1>
-        Total File Size: <span style={styles.statistic}>N/A</span>
+        Total File Size: <span style={styles.statistic}>{totalDataSize}</span>
       </h1>
       <Divider />
       <div style={styles.headerContainer}>
@@ -77,6 +92,7 @@ const Summary: React.FC<Props> = ({ numItems, numFiles }) => {
             type="primary"
             htmlType="submit"
             icon={<DownloadOutlined />}
+            disabled
           ></Button>
         </Form.Item>
       </Form>

--- a/frontend/src/components/Search/FilesTable.test.tsx
+++ b/frontend/src/components/Search/FilesTable.test.tsx
@@ -139,6 +139,7 @@ describe('test FilesTable component', () => {
                 id: 'id',
                 title: 'title',
                 checksum: 'checksum',
+                size: 1,
                 url: ['https://testdownload.com|HTTPServer'],
               },
             ],
@@ -165,7 +166,7 @@ describe('test FilesTable component', () => {
 
     // Select first cell row
     const firstRow = getByRole('row', {
-      name: 'title checksum HTTPServer download',
+      name: 'title checksum 1 Bytes HTTPServer download',
     });
     expect(firstRow).toBeTruthy();
 

--- a/frontend/src/components/Search/FilesTable.tsx
+++ b/frontend/src/components/Search/FilesTable.tsx
@@ -8,7 +8,7 @@ import Alert from '../Feedback/Alert';
 import Button from '../General/Button';
 
 import { fetchFiles } from '../../utils/api';
-import { parseUrl } from '../../utils/utils';
+import { parseUrl, formatBytes } from '../../utils/utils';
 
 export type DownloadUrls = {
   downloadType: string | undefined;
@@ -74,6 +74,9 @@ const FilesTable: React.FC<Props> = ({ id }) => {
         dataIndex: 'size',
         width: 100,
         key: 'size',
+        render: (size: number) => {
+          return formatBytes(size);
+        },
       },
       {
         title: 'Download',

--- a/frontend/src/components/Search/Table.test.tsx
+++ b/frontend/src/components/Search/Table.test.tsx
@@ -13,6 +13,7 @@ const defaultProps: Props = {
       number_of_files: 3,
       data_node: 'node.gov',
       version: 1,
+      size: 1,
       access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
       citation_url: ['https://foo.bar'],
     },
@@ -22,6 +23,7 @@ const defaultProps: Props = {
       number_of_files: 2,
       data_node: 'node.gov',
       version: 1,
+      size: 1,
       access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
       citation_url: ['https://foo.bar'],
     },
@@ -69,7 +71,7 @@ it('renders record metadata in an expandable panel', () => {
 
   // Check a record row exist
   const row = getByRole('row', {
-    name: 'right-circle 3 node.gov 1 HTTPServer download plus',
+    name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(row).toBeTruthy();
 
@@ -132,7 +134,8 @@ it('renders "PID" button when the record has a "xlink" key/value, vice versa', (
 
   // Check first row exists
   const firstRow = getByRole('row', {
-    name: 'right-circle 3 node.gov 1 HTTPServer download PID Further Info plus',
+    name:
+      'right-circle 3 1 Bytes node.gov 1 HTTPServer download PID Further Info plus',
   });
   expect(firstRow).toBeTruthy();
 
@@ -144,7 +147,7 @@ it('renders "PID" button when the record has a "xlink" key/value, vice versa', (
 
   // Check second row exists
   const secondRow = getByRole('row', {
-    name: 'right-circle 2 node.gov 1 HTTPServer download plus',
+    name: 'right-circle 2 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(secondRow).toBeTruthy();
 
@@ -166,7 +169,7 @@ it('renders add or remove button for items in or not in the cart respectively, a
 
   // Check first row exists
   const firstRow = getByRole('row', {
-    name: 'right-circle 3 node.gov 1 HTTPServer download minus',
+    name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download minus',
   });
   expect(firstRow).toBeTruthy();
 
@@ -177,7 +180,7 @@ it('renders add or remove button for items in or not in the cart respectively, a
 
   // Check second row exists
   const secondRow = getByRole('row', {
-    name: 'right-circle 2 node.gov 1 HTTPServer download plus',
+    name: 'right-circle 2 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(secondRow).toBeTruthy();
 
@@ -196,7 +199,7 @@ it('handles when clicking the select checkbox for a row', () => {
 
   // Check a record row exist
   const row = getByRole('row', {
-    name: 'right-circle 3 node.gov 1 HTTPServer download plus',
+    name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(row).toBeTruthy();
 

--- a/frontend/src/components/Search/Table.tsx
+++ b/frontend/src/components/Search/Table.tsx
@@ -15,7 +15,7 @@ import FilesTable from './FilesTable';
 import Button from '../General/Button';
 import Divider from '../General/Divider';
 
-import { hasKey, parseUrl } from '../../utils/utils';
+import { formatBytes, hasKey, parseUrl } from '../../utils/utils';
 import './Search.css';
 
 export type Props = {
@@ -158,6 +158,13 @@ const Table: React.FC<Props> = ({
       key: 'number_of_files',
       width: 100,
       render: (numberOfFiles: number) => <p>{numberOfFiles}</p>,
+    },
+    {
+      title: 'Total Size',
+      dataIndex: 'size',
+      key: 'size',
+      width: 100,
+      render: (size: number) => <p>{formatBytes(size)}</p>,
     },
     {
       title: 'Node',

--- a/frontend/src/components/Search/index.test.tsx
+++ b/frontend/src/components/Search/index.test.tsx
@@ -41,6 +41,7 @@ describe('test Search component', () => {
             number_of_files: 3,
             data_node: 'node.gov',
             version: 1,
+            size: 1,
             access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
           },
           {
@@ -49,6 +50,7 @@ describe('test Search component', () => {
             number_of_files: 2,
             data_node: 'node.gov',
             version: 1,
+            size: 1,
             access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
           },
         ],
@@ -224,7 +226,7 @@ describe('test Search component', () => {
 
     // Select the first row
     const firstRow = getByRole('row', {
-      name: 'right-circle 3 node.gov 1 HTTPServer download plus',
+      name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download plus',
     });
     expect(firstRow).toBeTruthy();
 

--- a/frontend/src/custom_types/search-result.d.ts
+++ b/frontend/src/custom_types/search-result.d.ts
@@ -7,5 +7,6 @@ type SearchResult = {
   citation_url?: string[] | [];
   further_info_url?: string[] | [];
   number_of_files: number;
+  size: number;
   [key: string]: string | string[] | number | undefined;
 };

--- a/frontend/src/utils/utils.test.ts
+++ b/frontend/src/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { isEmpty, humanize, hasKey } from './utils';
+import { isEmpty, formatBytes, humanize, hasKey } from './utils';
 
 describe('Test isEmpty', () => {
   test('isEmpty returns true with empty object', () => {
@@ -31,5 +31,17 @@ describe('Test hasKey', () => {
   it('returns false if key is not found ', () => {
     const testObj = {};
     expect(hasKey(testObj, 'findKey')).toBeFalsy();
+  });
+});
+
+describe('Test formatBytes', () => {
+  it('returns the correct rounded format', () => {
+    expect(formatBytes(0)).toEqual('0 Bytes');
+    expect(formatBytes(1, -1)).toEqual('1 Bytes');
+    expect(formatBytes(1024, 2)).toEqual('1 KB');
+    expect(formatBytes(10294828, 3)).toEqual('9.818 MB');
+    expect(formatBytes(2 ** 30, 0)).toEqual('1 GB');
+    expect(formatBytes(2 ** 40)).toEqual('1 TB');
+    expect(formatBytes(2 ** 50)).toEqual('1 PB');
   });
 });

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -33,3 +33,19 @@ export const hasKey = (
 ): boolean => {
   return Object.prototype.hasOwnProperty.call(obj, key);
 };
+
+/**
+ * Converts binary bytes into another size
+ * Source: https://stackoverflow.com/a/18650828
+ */
+export const formatBytes = (bytes: number, decimals = 2): string => {
+  if (bytes === 0) return '0 Bytes';
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / k ** i).toFixed(dm))} ${sizes[i]}`;
+};


### PR DESCRIPTION
This PR adds file size unit conversion in tables.

Summary of Changes
- Update tests for 100% coverage
- Add function `formatBytes`
- Update `FilesTable` to call `formatBytes` for unit conversion
- Add Size column to `Table` component
- Fix `act` warning in `App` tests by adding `await` on line 468
- Add `size` attribute to `SearchResult` type definition  