### PR TITLE
Update django to 3.0.7

### DIFF
--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -1,7 +1,7 @@
 # Core
 # ------------------------------------------------------------------------------
 pytz==2020.1  # https://github.com/stub42/pytz
-django==3.0.6  # pyup: < 3.1  # https://www.djangoproject.com/
+django==3.0.7  # pyup: < 3.1  # https://www.djangoproject.com/
 django-environ==0.4.5  # https://github.com/joke2k/django-environ
 gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
 newrelic==5.12.0.140  # https://pypi.org/project/newrelic/


### PR DESCRIPTION
Due to security issues with 3.0.6, which was causing pull request check failures.