### PR TITLE
Add fixtures and mock-service-worker for tests to replace mocking axios

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=REACT_APP_PROTOCOL::http://"
+          echo "::set-env name=REACT_APP_API_PROTOCOL::http://"
           echo "::set-env name=REACT_APP_API_URL::localhost"
           echo "::set-env name=REACT_APP_API_PORT::8000"
           echo "::set-env name=REACT_APP_ESGF_NODE_PROTOCOL::https://"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-react": "7.20.0",
     "eslint-plugin-react-hooks": "4.0.4",
     "jest-environment-jsdom-sixteen": "1.0.3",
+    "msw": "^0.19.3",
     "prettier": "2.0.5"
   },
   "jest": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => {
   >({});
   // The available facets based on the fetched results
   const [availableFacets, setAvailableFacets] = React.useState<
-    AvailableFacets | Record<string, unknown>
+    ParsedFacets | Record<string, unknown>
   >({});
   // The active applied free-text inputs in the search criteria
   const [textInputs, setTextInputs] = React.useState<TextInputs | []>([]);
@@ -134,7 +134,7 @@ const App: React.FC = () => {
    * @param {arrayOf(objectOf(any))} selectedItems
    */
   const handleCart = (
-    selectedItems: SearchResult[],
+    selectedItems: RawSearchResult[],
     operation: string
   ): void => {
     /* istanbul ignore else */
@@ -180,7 +180,7 @@ const App: React.FC = () => {
   /**
    * Handles available facets fetched from the API
    */
-  const handleSetAvailableFacets = (facets: AvailableFacets): void => {
+  const handleSetAvailableFacets = (facets: ParsedFacets): void => {
     setAvailableFacets(facets);
   };
 

--- a/frontend/src/__mocks__/axios.ts
+++ b/frontend/src/__mocks__/axios.ts
@@ -1,8 +1,0 @@
-// Mock file for axios
-// https://stackoverflow.com/questions/51393952/mock-inner-axios-create
-import axios from 'axios';
-
-const mockAxios: jest.Mocked<typeof axios> = jest.genMockFromModule('axios');
-mockAxios.create = jest.fn(() => mockAxios);
-
-export default mockAxios;

--- a/frontend/src/axios/index.ts
+++ b/frontend/src/axios/index.ts
@@ -1,10 +1,9 @@
 import axios from 'axios';
 import httpAdapter from 'axios/lib/adapters/http';
+import { apiBaseUrl } from '../env';
 
 export default axios.create({
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   adapter: httpAdapter,
-  baseURL: `${process.env.REACT_APP_API_PROTOCOL || 'http://'}${
-    process.env.REACT_APP_API_URL || 'localhost'
-  }:${process.env.REACT_APP_API_PORT || 8000}`,
+  baseURL: apiBaseUrl,
 });

--- a/frontend/src/components/Cart/Items.tsx
+++ b/frontend/src/components/Cart/Items.tsx
@@ -21,8 +21,8 @@ const styles = {
 };
 
 export type Props = {
-  cart: SearchResult[] | [];
-  handleCart: (item: SearchResult[], action: string) => void;
+  cart: RawSearchResult[] | [];
+  handleCart: (item: RawSearchResult[], action: string) => void;
   clearCart: () => void;
 };
 

--- a/frontend/src/components/Cart/Searches.test.tsx
+++ b/frontend/src/components/Cart/Searches.test.tsx
@@ -3,22 +3,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import Searches, { Props } from './Searches';
+import { savedSearchesFixture } from '../../test/fixtures';
 
 afterEach(() => {
   jest.clearAllMocks();
 });
 
 const defaultProps: Props = {
-  savedSearches: [
-    {
-      id: 'id',
-      project: { name: 'foo', facets_url: 'https://fubar.gov/?' },
-      defaultFacets: { latest: true, replica: false },
-      textInputs: ['foo'],
-      activeFacets: { foo: ['option1', 'option2'], baz: ['option1'] },
-      numResults: 1,
-    },
-  ],
+  savedSearches: savedSearchesFixture(),
   handleRemoveSearch: jest.fn(),
   handleApplySearch: jest.fn(),
 };

--- a/frontend/src/components/Cart/Summary.test.tsx
+++ b/frontend/src/components/Cart/Summary.test.tsx
@@ -4,26 +4,10 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { fireEvent, render } from '@testing-library/react';
 
 import Summary, { Props } from './Summary';
+import { cartFixture } from '../../test/fixtures';
 
 const defaultProps: Props = {
-  cart: [
-    {
-      id: 'foo',
-      url: ['foo.bar'],
-      number_of_files: 3,
-      data_node: 'node.gov',
-      version: 1,
-      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
-    },
-    {
-      id: 'bar',
-      url: ['foo.bar'],
-      number_of_files: 2,
-      data_node: 'node.gov',
-      version: 1,
-      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
-    },
-  ],
+  cart: cartFixture(),
 };
 
 test('renders without crashing', () => {
@@ -46,7 +30,7 @@ it('shows the correct number of datasets and files', () => {
     getByText((_, node) => node.textContent === 'Number of Datasets: 2')
   ).toBeTruthy();
   expect(
-    getByText((_, node) => node.textContent === 'Number of Files: 5')
+    getByText((_, node) => node.textContent === 'Number of Files: 6')
   ).toBeTruthy();
 });
 

--- a/frontend/src/components/Cart/Summary.tsx
+++ b/frontend/src/components/Cart/Summary.tsx
@@ -30,13 +30,13 @@ const Summary: React.FC<Props> = ({ cart }) => {
   let numFiles = 0;
   let totalDataSize = '0';
   if (cart.length > 0) {
-    numFiles = (cart as SearchResult[]).reduce(
-      (acc: number, dataset: SearchResult) => acc + dataset.number_of_files,
+    numFiles = (cart as RawSearchResult[]).reduce(
+      (acc: number, dataset: RawSearchResult) => acc + dataset.number_of_files,
       0
     );
 
-    const rawDataSize = (cart as SearchResult[]).reduce(
-      (acc: number, dataset: SearchResult) => acc + dataset.size,
+    const rawDataSize = (cart as RawSearchResult[]).reduce(
+      (acc: number, dataset: RawSearchResult) => acc + dataset.size,
       0
     );
     totalDataSize = formatBytes(rawDataSize);

--- a/frontend/src/components/Cart/index.test.tsx
+++ b/frontend/src/components/Cart/index.test.tsx
@@ -4,42 +4,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 
 import Cart, { Props } from './index';
-import mockAxios from '../../__mocks__/axios';
-
-// API return data
-const data = { response: { numFound: 1 } };
+import { cartFixture, savedSearchesFixture } from '../../test/fixtures';
 
 const defaultProps: Props = {
-  cart: [
-    {
-      id: 'foo',
-      url: ['foo.bar'],
-      number_of_files: 3,
-      data_node: 'node.gov',
-      version: 1,
-      size: 1,
-      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
-    },
-    {
-      id: 'bar',
-      url: ['foo.bar'],
-      number_of_files: 2,
-      data_node: 'node.gov',
-      version: 1,
-      size: 1,
-      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
-    },
-  ],
-  savedSearches: [
-    {
-      id: 'id',
-      project: { name: 'foo', facets_url: 'https://fubar.gov/?' },
-      defaultFacets: { latest: true, replica: false },
-      activeFacets: { foo: ['option1', 'option2'], baz: ['option1'] },
-      textInputs: ['foo'],
-      numResults: 1,
-    },
-  ],
+  cart: cartFixture(),
+  savedSearches: savedSearchesFixture(),
   handleCart: jest.fn(),
   clearCart: jest.fn(),
   handleRemoveSearch: jest.fn(),
@@ -66,12 +35,6 @@ afterEach(() => {
 });
 
 it('handles tab switching and saved search actions', async () => {
-  mockAxios.get.mockImplementationOnce(() =>
-    Promise.resolve({
-      data,
-    })
-  );
-
   const { getByRole, getByTestId } = render(
     <MemoryRouter>
       <Cart {...defaultProps} />
@@ -99,7 +62,6 @@ it('handles tab switching and saved search actions', async () => {
 
   // Wait for cart to re-render
   await waitFor(() => getByTestId('cart'));
-
   // Check apply search button renders and click it
   const applyBtn = await waitFor(() =>
     getByRole('img', { name: 'search', hidden: true })

--- a/frontend/src/components/Cart/index.tsx
+++ b/frontend/src/components/Cart/index.tsx
@@ -7,9 +7,9 @@ import Searches from './Searches';
 import Items from './Items';
 
 export type Props = {
-  cart: SearchResult[] | [];
+  cart: RawSearchResult[] | [];
   savedSearches: SavedSearch[] | [];
-  handleCart: (item: SearchResult[], action: string) => void;
+  handleCart: (item: RawSearchResult[], action: string) => void;
   clearCart: () => void;
   handleRemoveSearch: (id: string) => void;
   handleApplySearch: (savedSearch: SavedSearch) => void;

--- a/frontend/src/components/Facets/FacetsForm.tsx
+++ b/frontend/src/components/Facets/FacetsForm.tsx
@@ -16,7 +16,7 @@ const styles: { [key: string]: React.CSSProperties } = {
 export type Props = {
   defaultFacets: DefaultFacets;
   activeFacets: ActiveFacets | Record<string, unknown>;
-  availableFacets: AvailableFacets;
+  availableFacets: ParsedFacets;
   handleFacetsForm: (allValues: { [key: string]: string[] | [] }) => void;
 };
 

--- a/frontend/src/components/Facets/ProjectForm.test.tsx
+++ b/frontend/src/components/Facets/ProjectForm.test.tsx
@@ -3,12 +3,13 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import ProjectsForm, { Props } from './ProjectForm';
+import { projectsFixture } from '../../test/fixtures';
 
 const defaultProps: Props = {
   activeProject: { name: 'foo' },
   activeFacets: { facet1: ['foo'] },
   projectsIsLoading: false,
-  projectsFetched: { results: [{ name: 'foo', facets_url: 'foo.bar' }] },
+  projectsFetched: { results: projectsFixture() },
   handleProjectForm: jest.fn(),
 };
 
@@ -36,4 +37,13 @@ it('renders empty form', () => {
   // Check submit button does not exist
   const submitBtn = queryByRole('img', { name: 'select' });
   expect(submitBtn).toBeNull();
+});
+
+it('renders error message when projects can"t be fetched', () => {
+  const { getByRole } = render(
+    <ProjectsForm {...defaultProps} projectsError={new Error('404')} />
+  );
+
+  const alertComponent = getByRole('img', { name: 'close-circle' });
+  expect(alertComponent).toBeTruthy();
 });

--- a/frontend/src/components/Facets/index.test.tsx
+++ b/frontend/src/components/Facets/index.test.tsx
@@ -3,48 +3,26 @@ import React from 'react';
 import { fireEvent, render, waitFor, within } from '@testing-library/react';
 
 import Facets, { Props } from './index';
-import mockAxios from '../../__mocks__/axios';
+import { parsedFacetsFixture, defaultFacetsFixture } from '../../test/fixtures';
 
 const defaultProps: Props = {
   activeProject: {},
-  defaultFacets: { latest: true, replica: false },
+  defaultFacets: defaultFacetsFixture(),
   activeFacets: {},
-  availableFacets: {
-    facet1: [
-      ['foo', 3],
-      ['bar', 5],
-    ],
-    facet2: [
-      ['baz', 2],
-      ['fubar', 3],
-    ],
-  },
+  availableFacets: parsedFacetsFixture(),
   handleProjectChange: jest.fn(),
   onSetFacets: jest.fn(),
 };
-
-// Need to mock axios for projects
-beforeEach(() => {
-  const results = [{ name: 'test1' }, { name: 'test2' }];
-
-  mockAxios.get.mockImplementationOnce(() =>
-    Promise.resolve({
-      data: {
-        results,
-      },
-    })
-  );
-});
 
 it('renders component', async () => {
   const { getByTestId } = render(<Facets {...defaultProps} />);
 
   // Check FacetsForm component renders
-  const facetsForm = getByTestId('facets-form');
+  const facetsForm = await waitFor(() => getByTestId('facets-form'));
   await waitFor(() => expect(facetsForm).toBeTruthy());
 
   // Check ProjectForm component renders
-  const projectForm = getByTestId('project-form');
+  const projectForm = await waitFor(() => getByTestId('project-form'));
   expect(projectForm).toBeTruthy();
 });
 
@@ -52,11 +30,11 @@ it('handles when the project form is submitted', async () => {
   const { getByTestId } = render(<Facets {...defaultProps} />);
 
   // Check FacetsForm component renders
-  const facetsForm = getByTestId('facets-form');
+  const facetsForm = await waitFor(() => getByTestId('facets-form'));
   await waitFor(() => expect(facetsForm).toBeTruthy());
 
   // Check ProjectForm component renders
-  const projectForm = getByTestId('project-form');
+  const projectForm = await waitFor(() => getByTestId('project-form'));
   expect(projectForm).toBeTruthy();
 
   // Check facet select form exists and mouseDown to expand list of options
@@ -84,12 +62,12 @@ it('handles facets form submission', async () => {
     <Facets {...defaultProps} activeProject={{ name: 'test1' }} />
   );
 
-  // Check FacetForm component renders
-  const facetsForm = getByTestId('facets-form');
+  // Check FacetsForm component renders
+  const facetsForm = await waitFor(() => getByTestId('facets-form'));
   await waitFor(() => expect(facetsForm).toBeTruthy());
 
   // Check ProjectForm component renders
-  const projectForm = getByTestId('project-form');
+  const projectForm = await waitFor(() => getByTestId('project-form'));
   expect(projectForm).toBeTruthy();
 
   // Open Collapse Panel in Collapse component for the facet1 form to render
@@ -119,12 +97,12 @@ it('handles facets form submission, including a facet key that is undefined', as
     <Facets {...defaultProps} activeProject={{ name: 'test1' }} />
   );
 
-  // Check Facetform component renders
-  const facetsForm = getByTestId('facets-form');
+  // Check FacetsForm component renders
+  const facetsForm = await waitFor(() => getByTestId('facets-form'));
   await waitFor(() => expect(facetsForm).toBeTruthy());
 
   // Check ProjectForm component renders
-  const projectForm = getByTestId('project-form');
+  const projectForm = await waitFor(() => getByTestId('project-form'));
   expect(projectForm).toBeTruthy();
 
   // Open Collapse Panel in Collapse component for the facet1 form to render

--- a/frontend/src/components/Facets/index.tsx
+++ b/frontend/src/components/Facets/index.tsx
@@ -19,7 +19,7 @@ export type Props = {
   activeProject: Project | Record<string, unknown>;
   defaultFacets: DefaultFacets;
   activeFacets: ActiveFacets | Record<string, unknown>;
-  availableFacets: AvailableFacets | Record<string, unknown>;
+  availableFacets: ParsedFacets | Record<string, unknown>;
   handleProjectChange: (selectedProj: Project) => void;
   onSetFacets: (defaults: DefaultFacets, active: ActiveFacets) => void;
 };
@@ -104,7 +104,7 @@ const Facets: React.FC<Props> = ({
         <FacetsForm
           defaultFacets={defaultFacets}
           activeFacets={activeFacets}
-          availableFacets={availableFacets as AvailableFacets}
+          availableFacets={availableFacets as ParsedFacets}
           handleFacetsForm={handleFacetsForm}
         />
       )}

--- a/frontend/src/components/NavBar/LeftMenu.test.tsx
+++ b/frontend/src/components/NavBar/LeftMenu.test.tsx
@@ -3,13 +3,11 @@ import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import LeftMenu, { Props } from './LeftMenu';
+import { projectsFixture } from '../../test/fixtures';
 
 const defaultProps: Props = {
   activeProject: { name: 'test1' },
-  projects: [
-    { name: 'test1', facets_url: 'foo.bar' },
-    { name: 'test2', facets_url: 'foo.bar' },
-  ],
+  projects: projectsFixture(),
   onSearch: jest.fn(),
   onProjectChange: jest.fn(),
 };

--- a/frontend/src/components/Search/Citation.tsx
+++ b/frontend/src/components/Search/Citation.tsx
@@ -30,7 +30,7 @@ type CitationProps = {
 
 const Citation: React.FC<CitationProps> = ({ url }) => {
   const { data, error, isLoading } = useAsync({
-    promiseFn: (fetchCitation as unknown) as PromiseFn<Citation>,
+    promiseFn: (fetchCitation as unknown) as PromiseFn<RawCitation>,
     url,
   });
 

--- a/frontend/src/components/Search/FilesTable.tsx
+++ b/frontend/src/components/Search/FilesTable.tsx
@@ -56,87 +56,87 @@ const FilesTable: React.FC<Props> = ({ id }) => {
     );
   }
 
+  let docs: RawSearchResult[] | [] = [];
   if (data) {
-    const { docs } = (data as {
-      response: { docs: SearchResult[] };
-    }).response;
-
-    const columns = [
-      {
-        title: 'File Title',
-        dataIndex: 'title',
-        size: 400,
-        key: 'title',
-      },
-      {
-        title: 'Checksum',
-        dataIndex: 'checksum',
-        key: 'checksum',
-      },
-      {
-        title: 'Size',
-        dataIndex: 'size',
-        width: 100,
-        key: 'size',
-        render: (size: number) => {
-          return formatBytes(size);
-        },
-      },
-      {
-        title: 'Download',
-        key: 'download',
-        width: 200,
-        render: (record: { url: string[] }) => {
-          const downloadUrls = genDownloadUrls(record.url);
-
-          return (
-            <span>
-              <Form
-                data-testid="download-form"
-                layout="inline"
-                onFinish={({ download }) => openDownloadUrl(download)}
-                initialValues={{ download: downloadUrls[0].downloadUrl }}
-              >
-                <Form.Item name="download">
-                  <Select style={{ width: 120 }}>
-                    {downloadUrls.map((option) => (
-                      <Select.Option
-                        key={option.downloadType}
-                        value={option.downloadUrl as React.ReactText}
-                      >
-                        {option.downloadType}
-                      </Select.Option>
-                    ))}
-                  </Select>
-                </Form.Item>
-                <Form.Item>
-                  <Button
-                    type="primary"
-                    htmlType="submit"
-                    icon={<DownloadOutlined />}
-                  ></Button>
-                </Form.Item>
-              </Form>
-            </span>
-          );
-        },
-      },
-    ];
-
-    return (
-      <TableD
-        data-testid="filesTable"
-        size="small"
-        loading={isLoading}
-        pagination={{ position: ['bottomCenter'], showSizeChanger: true }}
-        columns={columns}
-        dataSource={docs}
-        rowKey="id"
-        scroll={{ y: 300 }}
-      />
-    );
+    docs = (data as {
+      response: { docs: RawSearchResult[] };
+    }).response.docs;
   }
-  return null;
+
+  const columns = [
+    {
+      title: 'File Title',
+      dataIndex: 'title',
+      size: 400,
+      key: 'title',
+    },
+    {
+      title: 'Checksum',
+      dataIndex: 'checksum',
+      key: 'checksum',
+    },
+    {
+      title: 'Size',
+      dataIndex: 'size',
+      width: 100,
+      key: 'size',
+      render: (size: number) => {
+        return formatBytes(size);
+      },
+    },
+    {
+      title: 'Download',
+      key: 'download',
+      width: 200,
+      render: (record: { url: string[] }) => {
+        const downloadUrls = genDownloadUrls(record.url);
+
+        return (
+          <span>
+            <Form
+              data-testid="download-form"
+              layout="inline"
+              onFinish={({ download }) => openDownloadUrl(download)}
+              initialValues={{ download: downloadUrls[0].downloadUrl }}
+            >
+              <Form.Item name="download">
+                <Select style={{ width: 120 }}>
+                  {downloadUrls.map((option) => (
+                    <Select.Option
+                      key={option.downloadType}
+                      value={option.downloadUrl as React.ReactText}
+                    >
+                      {option.downloadType}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </Form.Item>
+              <Form.Item>
+                <Button
+                  type="primary"
+                  htmlType="submit"
+                  icon={<DownloadOutlined />}
+                ></Button>
+              </Form.Item>
+            </Form>
+          </span>
+        );
+      },
+    },
+  ];
+
+  return (
+    <TableD
+      data-testid="filesTable"
+      size="small"
+      loading={isLoading}
+      pagination={{ position: ['bottomCenter'], showSizeChanger: true }}
+      columns={columns}
+      dataSource={docs}
+      rowKey="id"
+      scroll={{ y: 300 }}
+    />
+  );
 };
 
 export default FilesTable;

--- a/frontend/src/components/Search/Table.test.tsx
+++ b/frontend/src/components/Search/Table.test.tsx
@@ -3,32 +3,12 @@ import React from 'react';
 import { fireEvent, render, within } from '@testing-library/react';
 
 import Table, { Props } from './Table';
+import { searchResultsFixture } from '../../test/fixtures';
 
 const defaultProps: Props = {
   loading: false,
-  results: [
-    {
-      id: 'foo',
-      url: [],
-      number_of_files: 3,
-      data_node: 'node.gov',
-      version: 1,
-      size: 1,
-      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
-      citation_url: ['https://foo.bar'],
-    },
-    {
-      id: 'bar',
-      url: [],
-      number_of_files: 2,
-      data_node: 'node.gov',
-      version: 1,
-      size: 1,
-      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
-      citation_url: ['https://foo.bar'],
-    },
-  ],
-  totalResults: 2,
+  results: searchResultsFixture(),
+  totalResults: searchResultsFixture().length,
   cart: [],
   handleCart: jest.fn(),
   handleRowSelect: jest.fn(),
@@ -71,7 +51,7 @@ it('renders record metadata in an expandable panel', () => {
 
   // Check a record row exist
   const row = getByRole('row', {
-    name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download plus',
+    name: 'right-circle foo 3 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(row).toBeTruthy();
 
@@ -135,7 +115,7 @@ it('renders "PID" button when the record has a "xlink" key/value, vice versa', (
   // Check first row exists
   const firstRow = getByRole('row', {
     name:
-      'right-circle 3 1 Bytes node.gov 1 HTTPServer download PID Further Info plus',
+      'right-circle foo 3 1 Bytes node.gov 1 HTTPServer download PID Further Info plus',
   });
   expect(firstRow).toBeTruthy();
 
@@ -147,7 +127,7 @@ it('renders "PID" button when the record has a "xlink" key/value, vice versa', (
 
   // Check second row exists
   const secondRow = getByRole('row', {
-    name: 'right-circle 2 1 Bytes node.gov 1 HTTPServer download plus',
+    name: 'right-circle bar 2 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(secondRow).toBeTruthy();
 
@@ -169,7 +149,7 @@ it('renders add or remove button for items in or not in the cart respectively, a
 
   // Check first row exists
   const firstRow = getByRole('row', {
-    name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download minus',
+    name: 'right-circle foo 3 1 Bytes node.gov 1 HTTPServer download minus',
   });
   expect(firstRow).toBeTruthy();
 
@@ -180,7 +160,7 @@ it('renders add or remove button for items in or not in the cart respectively, a
 
   // Check second row exists
   const secondRow = getByRole('row', {
-    name: 'right-circle 2 1 Bytes node.gov 1 HTTPServer download plus',
+    name: 'right-circle bar 2 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(secondRow).toBeTruthy();
 
@@ -199,7 +179,7 @@ it('handles when clicking the select checkbox for a row', () => {
 
   // Check a record row exist
   const row = getByRole('row', {
-    name: 'right-circle 3 1 Bytes node.gov 1 HTTPServer download plus',
+    name: 'right-circle foo 3 1 Bytes node.gov 1 HTTPServer download plus',
   });
   expect(row).toBeTruthy();
 

--- a/frontend/src/components/Search/Table.tsx
+++ b/frontend/src/components/Search/Table.tsx
@@ -20,11 +20,11 @@ import './Search.css';
 
 export type Props = {
   loading: boolean;
-  results: SearchResult[] | [];
+  results: RawSearchResult[] | [];
   totalResults?: number;
   cart: Cart | [];
-  handleCart: (item: SearchResult[], action: string) => void;
-  handleRowSelect?: (selectedRows: SearchResult[] | []) => void;
+  handleCart: (item: RawSearchResult[], action: string) => void;
+  handleRowSelect?: (selectedRows: RawSearchResult[] | []) => void;
   handlePagination?: (page: number, pageSize: number) => void;
   handlePageSizeChange?: (size: number) => void;
 };
@@ -52,7 +52,7 @@ const Table: React.FC<Props> = ({
         handlePageSizeChange && handlePageSizeChange(size),
     } as TablePaginationConfig,
     expandable: {
-      expandedRowRender: (record: SearchResult) => {
+      expandedRowRender: (record: RawSearchResult) => {
         const metaData = Object.entries(record).map(([k, v]) => ({
           value: `${k}: ${v as string}`,
         }));
@@ -109,10 +109,10 @@ const Table: React.FC<Props> = ({
       }: {
         expanded: boolean;
         onExpand: (
-          record: SearchResult,
+          record: RawSearchResult,
           e: React.MouseEvent<HTMLSpanElement, MouseEvent>
         ) => void;
-        record: SearchResult;
+        record: RawSearchResult;
       }): React.ReactElement =>
         expanded ? (
           <DownCircleOutlined onClick={(e) => onExpand(record, e)} />
@@ -121,7 +121,7 @@ const Table: React.FC<Props> = ({
         ),
     },
     rowSelection: {
-      getCheckboxProps: (record: SearchResult) =>
+      getCheckboxProps: (record: RawSearchResult) =>
         cart.includes(record as never, 0)
           ? { disabled: true }
           : { disabled: false },
@@ -181,7 +181,7 @@ const Table: React.FC<Props> = ({
       title: 'Download',
       key: 'download',
       width: 200,
-      render: (record: SearchResult) => (
+      render: (record: RawSearchResult) => (
         <span>
           <Form layout="inline">
             <Form.Item>
@@ -210,7 +210,7 @@ const Table: React.FC<Props> = ({
       title: 'Additional',
       key: 'additional',
       width: 200,
-      render: (record: SearchResult) => {
+      render: (record: RawSearchResult) => {
         return (
           <>
             {hasKey(record, 'xlink') && (
@@ -241,7 +241,7 @@ const Table: React.FC<Props> = ({
       title: 'Cart',
       key: 'cart',
       width: 50,
-      render: (record: SearchResult) => {
+      render: (record: RawSearchResult) => {
         if (cart.includes(record as never, 0)) {
           return (
             <>

--- a/frontend/src/components/Search/index.tsx
+++ b/frontend/src/components/Search/index.tsx
@@ -35,8 +35,8 @@ const styles = {
  * Joins adjacent elements of the facets obj into a tuple using reduce().
  * https://stackoverflow.com/questions/37270508/javascript-function-that-converts-array-to-array-of-2-tuples
  */
-export const parseFacets = (facets: FetchedFacets): AvailableFacets => {
-  const res = (facets as unknown) as AvailableFacets;
+export const parseFacets = (facets: RawFacets): ParsedFacets => {
+  const res = (facets as unknown) as ParsedFacets;
   const keys: string[] = Object.keys(facets);
 
   keys.forEach((key) => {
@@ -101,8 +101,8 @@ export type Props = {
   cart: Cart | [];
   onRemoveTag: (removedTag: Tag, type: string) => void;
   onClearTags: () => void;
-  handleCart: (selectedItems: SearchResult[], action: string) => void;
-  setAvailableFacets: (parsedFacets: AvailableFacets) => void;
+  handleCart: (selectedItems: RawSearchResult[], action: string) => void;
+  setAvailableFacets: (parsedFacets: ParsedFacets) => void;
   handleSaveSearch: (numResults: number) => void;
 };
 
@@ -129,14 +129,14 @@ const Search: React.FC<Props> = ({
   );
   // Parsed version of the returned facet fields
   const [parsedFacets, setParsedFacets] = React.useState<
-    AvailableFacets | Record<string, unknown>
+    ParsedFacets | Record<string, unknown>
   >({});
   // The current request URL generated when fetching results
   const [curReqUrl, setCurReqUrl] = React.useState<string | null>(null);
   // Items selected in the data table
-  const [selectedItems, setSelectedItems] = React.useState<SearchResult[] | []>(
-    []
-  );
+  const [selectedItems, setSelectedItems] = React.useState<
+    RawSearchResult[] | []
+  >([]);
   // Pagination options in the data table
   const [pagination, setPagination] = React.useState<{
     page: number;
@@ -175,22 +175,22 @@ const Search: React.FC<Props> = ({
   React.useEffect(() => {
     if (results && !isEmpty(results)) {
       const { facet_fields: facetFields } = (results as {
-        facet_counts: { facet_fields: FetchedFacets };
+        facet_counts: { facet_fields: RawFacets };
       }).facet_counts;
       setParsedFacets(parseFacets(facetFields));
     }
   }, [results]);
 
   React.useEffect(() => {
-    setAvailableFacets(parsedFacets as AvailableFacets);
+    setAvailableFacets(parsedFacets as ParsedFacets);
   }, [parsedFacets, setAvailableFacets]);
 
   /**
-   * Handles when the user selectes individual items and adds to the cart
+   * Handles when the user selected individual items and adds to the cart.
    * This function filters out items that have been already added to the cart,
    * which is indicated as disabled on the UI.
    */
-  const handleSelect = (selectedRows: SearchResult[] | []): void => {
+  const handleSelect = (selectedRows: RawSearchResult[] | []): void => {
     setSelectedItems(selectedRows);
   };
 
@@ -219,14 +219,12 @@ const Search: React.FC<Props> = ({
     );
   }
 
-  // Destructure the results object if it exists
-  // TODO: Figure out a better way annotate type for 'results'
   let numFound = 0;
-  let docs: SearchResult[] = [];
+  let docs: RawSearchResult[] = [];
   if (results) {
     numFound = (results as { response: { numFound: number } }).response
       .numFound;
-    docs = (results as { response: { docs: SearchResult[] } }).response.docs;
+    docs = (results as { response: { docs: RawSearchResult[] } }).response.docs;
   }
 
   return (

--- a/frontend/src/custom_types/available-facets.d.ts
+++ b/frontend/src/custom_types/available-facets.d.ts
@@ -1,1 +1,0 @@
-type AvailableFacets = Record<string, [string, number][]>;

--- a/frontend/src/custom_types/cart.d.ts
+++ b/frontend/src/custom_types/cart.d.ts
@@ -1,1 +1,1 @@
-type Cart = SearchResult[];
+type Cart = RawSearchResult[];

--- a/frontend/src/custom_types/esg-search-api-response.d.ts
+++ b/frontend/src/custom_types/esg-search-api-response.d.ts
@@ -1,0 +1,4 @@
+type ESGSearchApiResponse = {
+  response: { numFound: number; docs: RawSearchResult[] };
+  facet_counts: { facet_fields: RawFacets };
+};

--- a/frontend/src/custom_types/fetched-facets.d.ts
+++ b/frontend/src/custom_types/fetched-facets.d.ts
@@ -1,1 +1,0 @@
-type FetchedFacets = Record<string, (string | number)[]>;

--- a/frontend/src/custom_types/parsed-facets.d.ts
+++ b/frontend/src/custom_types/parsed-facets.d.ts
@@ -1,0 +1,1 @@
+type ParsedFacets = Record<string, [string, number][]>;

--- a/frontend/src/custom_types/raw-citation.d.ts
+++ b/frontend/src/custom_types/raw-citation.d.ts
@@ -1,4 +1,4 @@
-type Citation = {
+type RawCitation = {
   identifier: { id: string; identifierType: string };
   creators: { [key: string]: string }[];
   titles: string;

--- a/frontend/src/custom_types/raw-facets.d.ts
+++ b/frontend/src/custom_types/raw-facets.d.ts
@@ -1,0 +1,1 @@
+type RawFacets = Record<string, (string | number)[]>;

--- a/frontend/src/custom_types/raw-search-result.d.ts
+++ b/frontend/src/custom_types/raw-search-result.d.ts
@@ -1,5 +1,5 @@
 // Type definition for a search result object, based on the ESG Search APi
-type SearchResult = {
+type RawSearchResult = {
   id: string;
   url: string[];
   access: string[];

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -1,0 +1,17 @@
+// This file sets environment variables as constants to be used in other files
+
+const apiProtocol = process.env.REACT_APP_API_PROTOCOL as string;
+const apiUrl = process.env.REACT_APP_API_URL as string;
+const apiPort = process.env.REACT_APP_API_PORT as string;
+export const apiBaseUrl = `${apiProtocol}${apiUrl}:${apiPort}`;
+
+const proxyProtocol = process.env.REACT_APP_PROXY_PROTOCOL as string;
+const proxyHost = process.env.REACT_APP_PROXY_HOST as string;
+const proxyPort = process.env.REACT_APP_PROXY_PORT as string;
+export const proxyString = `${proxyProtocol}${proxyHost}:${proxyPort}`;
+
+export const nodeProtocol = `${
+  process.env.REACT_APP_ESGF_NODE_PROTOCOL as string
+}`;
+export const nodeUrl = `${process.env.REACT_APP_ESGF_NODE_URL as string}`;
+export const nodeRoute = `${nodeProtocol}${nodeUrl}`;

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -3,6 +3,12 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+import './test/setup-env';
+
+beforeEach(() => {
+  // Set timeout since some tests run longer than 5000ms
+  jest.setTimeout(10000);
+});
 
 // This resolves 'TypeError: window.matchMedia is not a function caused by JSDom.
 // Source: https://stackoverflow.com/a/53449595

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -1,0 +1,152 @@
+// This file contains fixtures to seed tests with dummy data.
+// Fixtures allows tests to be maintainable (especially in the case of updated
+// APIs) and reduce duplicate hard-coded dummy data.
+
+/**
+ * Project fixture, related to the Project model from the MetaGrid API
+ */
+export const projectFixture = (props: Partial<Project> = {}): Project => {
+  const defaults: Project = {
+    name: 'test1',
+    facets_url:
+      'https://esgf-node.llnl.gov/esg-search/search/?offset=0&limit=0',
+  };
+  return { ...defaults, ...props } as Project;
+};
+
+export const projectsFixture = (): Project[] => {
+  return [projectFixture(), projectFixture({ name: 'test2' })];
+};
+
+/**
+ * Search result fixture, related to the ESG Search API.
+ * In the API, this value is stored in an array of objects under the 'docs' key
+ * of the HTTP  response object.
+ */
+export const searchResultFixture = (
+  props: Partial<RawSearchResult> = {}
+): RawSearchResult => {
+  const defaults: RawSearchResult = {
+    id: 'foo',
+    title: 'foo',
+    url: ['foo.bar'],
+    number_of_files: 3,
+    data_node: 'node.gov',
+    version: 1,
+    size: 1,
+    access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
+    citation_url: ['https://foo.bar'],
+  };
+  return { ...defaults, ...props };
+};
+
+export const searchResultsFixture = (): RawSearchResult[] => {
+  return [
+    searchResultFixture(),
+    searchResultFixture({ id: 'bar', title: 'bar', number_of_files: 2 }),
+  ];
+};
+
+/**
+ * Raw facets fixture, related to the ESG Search API.
+ */
+export const rawFacetsFixture = (props: Partial<RawFacets> = {}): RawFacets => {
+  const defaults: RawFacets = {
+    facet1: ['foo', 3, 'bar', 5],
+    facet2: ['baz', 2, 'fubar', 3],
+  };
+  return { ...defaults, ...props } as RawFacets;
+};
+
+/**
+ * Parsed facets fixture, which is the raw facets parsed using a helper function.
+ */
+export const parsedFacetsFixture = (
+  props: Partial<ParsedFacets> = {}
+): ParsedFacets => {
+  const defaults: ParsedFacets = {
+    facet1: [
+      ['foo', 3],
+      ['bar', 5],
+    ],
+    facet2: [
+      ['baz', 2],
+      ['fubar', 3],
+    ],
+  };
+  return { ...defaults, ...props } as ParsedFacets;
+};
+
+/**
+ * Cart fixture, which contains multiple search results.
+ */
+export const cartFixture = (): Cart => {
+  return [searchResultFixture(), searchResultFixture()];
+};
+
+/**
+ * Citation fixture, related to the Citation API.
+ */
+export const citationFixture = (
+  props: Partial<RawCitation> = {}
+): RawCitation => {
+  const defaults: RawCitation = {
+    identifier: { id: 'an_id', identifierType: 'DOI' },
+    creators: [{ creatorName: 'Bob' }, { creatorName: 'Tom' }],
+    identifierDOI: '',
+    creatorsList: '',
+    titles: 'title',
+    publisher: 'publisher',
+    publicationYear: 2020,
+  };
+
+  return { ...defaults, ...props };
+};
+
+/**
+ * Saved search fixture.
+ */
+export const savedSearchFixture = (
+  props: Partial<SavedSearch> = {}
+): SavedSearch => {
+  const defaults: SavedSearch = {
+    id: 'id',
+    project: {
+      name: 'foo',
+      facets_url:
+        'latest=true&replica=false&query=foo&baz=option1&foo=option1,option2',
+    },
+    defaultFacets: { latest: true, replica: false },
+    activeFacets: { foo: ['option1', 'option2'], baz: ['option1'] },
+    textInputs: ['foo'],
+    numResults: 1,
+  };
+
+  return { ...defaults, ...props } as SavedSearch;
+};
+
+export const savedSearchesFixture = (): SavedSearch[] => {
+  return [savedSearchFixture()];
+};
+
+export const defaultFacetsFixture = (
+  props: Partial<DefaultFacets> = {}
+): DefaultFacets => {
+  const defaults: DefaultFacets = { latest: true, replica: false };
+  return { ...defaults, ...props } as DefaultFacets;
+};
+
+/**
+ * ESG Search API fixture
+ */
+export const esgSearchApiFixture = (): ESGSearchApiResponse => {
+  return {
+    response: {
+      numFound: searchResultsFixture().length,
+      docs: searchResultsFixture(),
+    },
+    facet_counts: {
+      facet_fields: rawFacetsFixture(),
+    },
+  };
+};

--- a/frontend/src/test/server-handlers.ts
+++ b/frontend/src/test/server-handlers.ts
@@ -1,0 +1,55 @@
+import { rest } from 'msw';
+import {
+  projectsFixture,
+  citationFixture,
+  esgSearchApiFixture,
+} from './fixtures';
+import { apiBaseUrl, nodeRoute, nodeUrl, proxyString } from '../env';
+
+type ApiRoutes = {
+  metagrid: string;
+  esgSearchDatasets: string;
+  esgSearchFiles: string;
+  citation: string;
+};
+
+// Routes for API services utilized by the app.
+export const apiRoutes: ApiRoutes = {
+  // MetaGrid API - projects
+  metagrid: `${apiBaseUrl}/api/v1/projects/`,
+  // ESGF Search API - datasets
+  esgSearchDatasets: `${proxyString}/${nodeRoute}/esg-search/search/`,
+  // ESGF Search API - files
+  esgSearchFiles: `${proxyString}/${nodeRoute}/search_files/:id/${nodeUrl}/`,
+  // ESGF Citation API (uses dummy link)
+  citation: `${proxyString}/citation_url`,
+};
+
+// Handlers for each route, which returns a corresponding fixture.
+// These handlers can be overridden in a test, for example when a 404 needs to
+// be returned to //display an error message within a component.
+const handlers = [
+  rest.get(apiRoutes.metagrid, (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json({ results: projectsFixture() }));
+  }),
+  rest.get(apiRoutes.esgSearchDatasets, (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(esgSearchApiFixture()));
+  }),
+  rest.get(apiRoutes.esgSearchFiles, (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(esgSearchApiFixture()));
+  }),
+  rest.get(apiRoutes.citation, (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(citationFixture()));
+  }),
+  // Default fallback handler
+  rest.get('*', (req, res, ctx) => {
+    // eslint-disable-next-line no-console
+    console.error(`Please add request handler for ${req.url.toString()}`);
+    return res(
+      ctx.status(500),
+      ctx.json({ error: 'You must add request handler.' })
+    );
+  }),
+];
+
+export default handlers;

--- a/frontend/src/test/server.handlers.test.ts
+++ b/frontend/src/test/server.handlers.test.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+it('returns fallback handler', async () => {
+  const result = axios.get('invalid_handler');
+  await expect(result).rejects.toThrow('500');
+});

--- a/frontend/src/test/server.ts
+++ b/frontend/src/test/server.ts
@@ -1,0 +1,8 @@
+// test/server.js
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import handlers from './server-handlers';
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+const server = setupServer(...handlers);
+export { server, rest };

--- a/frontend/src/test/setup-env.ts
+++ b/frontend/src/test/setup-env.ts
@@ -1,0 +1,9 @@
+// test/setup-env.js
+// add this to your setupFilesAfterEnv config in jest so it's imported for every test file
+import { server, rest } from './server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+export { server, rest };

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,16 +1,8 @@
 import queryString from 'query-string';
 
 import axios from '../axios';
-
-// Stringified version of proxy to be used for API calls
-export const proxyString = `${process.env.REACT_APP_PROXY_PROTOCOL as string}${
-  process.env.REACT_APP_PROXY_HOST as string
-}:${process.env.REACT_APP_PROXY_PORT as string}`;
-
-export const nodeProtocol = `${
-  process.env.REACT_APP_ESGF_NODE_PROTOCOL as string
-}`;
-export const nodeUrl = `${process.env.REACT_APP_ESGF_NODE_URL as string}`;
+import { apiRoutes } from '../test/server-handlers';
+import { proxyString } from '../env';
 
 /**
  * Fetches a list of projects.
@@ -68,7 +60,7 @@ export const genUrlQuery = (
     .replace('limit=0', `limit=${pagination.pageSize}`)
     .replace('offset=0', `offset=${offset}`);
 
-  const url = `${nodeProtocol}${nodeUrl}/esg-search/search/?${newBaseUrl}&${defaultFacetsStr}&${stringifyText}&${activeFacetsStr}`;
+  const url = `${apiRoutes.esgSearchDatasets}?${newBaseUrl}&${defaultFacetsStr}&${stringifyText}&${activeFacetsStr}`;
   return url;
 };
 
@@ -98,7 +90,7 @@ export const fetchResults = async (
   }
 
   return axios
-    .get(`${proxyString}/${reqUrlStr}`)
+    .get(`${reqUrlStr}`)
     .then((res) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return res.data as Promise<{ [key: string]: any }>;
@@ -112,7 +104,7 @@ export const fetchResults = async (
  * Performs process on citation objects.
  */
 
-export const processCitation = (citation: Citation): Citation => {
+export const processCitation = (citation: RawCitation): RawCitation => {
   const newCitation = citation;
 
   newCitation.identifierDOI = `http://${newCitation.identifier.identifierType.toLowerCase()}.org/${
@@ -156,9 +148,9 @@ export const fetchFiles = async ({
   id: string;
 }): // eslint-disable-next-line @typescript-eslint/no-explicit-any
 Promise<{ [key: string]: any }> => {
-  const url = `${nodeProtocol}${nodeUrl}/search_files/${id}/${nodeUrl}/?limit=10`;
+  const url = `${apiRoutes.esgSearchFiles.replace(':id', id)}?limit=10`;
   return axios
-    .get(`${proxyString}/${url}`)
+    .get(url)
     .then((res) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return res.data as Promise<{ [key: string]: any }>;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1380,6 +1380,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@open-draft/until@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
@@ -1567,6 +1572,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -3181,6 +3191,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 clone-deep@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
@@ -3410,6 +3429,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -5015,7 +5039,7 @@ find-cache-dir@^3.2.0:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-find-up@4.1.0, find-up@^4.0.0:
+find-up@4.1.0, find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -5373,6 +5397,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+graphql@^15.0.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.1.0.tgz#b93e28de805294ec08e1630d901db550cb8960a1"
+  integrity sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -5490,6 +5519,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+headers-utils@^1.1.9, headers-utils@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-1.2.0.tgz#5e10d1bc9d2bccf789547afca5b991a3167241e8"
+  integrity sha512-4/BMXcWrJErw7JpM87gF8MNEXcIMLzepYZjNRv/P9ctgupl2Ywa3u1PgHtNhSRq84bHH9Ndlkdy7bSi+bZ9I9A==
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -7621,6 +7655,22 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+msw@^0.19.3:
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-0.19.3.tgz#88f39edbd37313bff15a0e7cd00c71406cbdbbae"
+  integrity sha512-HYLnyrCDDPP72GG/CeHPhBjHsZFYkz36rJLXDWccZWNA24gYjgrcp9iVqqitk2cI6NAJwsupRml9GkfpJBB74w==
+  dependencies:
+    "@open-draft/until" "^1.0.0"
+    "@types/cookie" "^0.3.3"
+    chalk "^4.0.0"
+    cookie "^0.4.1"
+    graphql "^15.0.0"
+    headers-utils "^1.1.9"
+    node-match-path "^0.4.2"
+    node-request-interceptor "^0.2.5"
+    statuses "^2.0.0"
+    yargs "^15.3.1"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -7733,6 +7783,11 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
+node-match-path@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.4.2.tgz#30cc39510fa493bff03c3d0d2fff711c868ec457"
+  integrity sha512-wfde4FOC5A8RTSUVZ7pTpBV+dJsr2vVxT6374VrNam6wnnhx6EvwAwL/E/r3AW/YU6XkeZggF5xfBlu4a/ULBg==
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
@@ -7753,6 +7808,14 @@ node-releases@^1.1.52, node-releases@^1.1.53:
   version "1.1.58"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.58.tgz#8ee20eef30fa60e52755fcc0942def5a734fe935"
   integrity sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==
+
+node-request-interceptor@^0.2.5:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.2.6.tgz#541278d7033bb6a8befb5dd793f83428cf6446a2"
+  integrity sha512-aJW1tPSM7nzuZFRe+C/KSz22GJO3CVFMxHHmMGX8Z+tjP7TCIVbzeckLFVfJG68BdVgrdOOP7Ejc57ag820eyA==
+  dependencies:
+    debug "^4.1.1"
+    headers-utils "^1.2.0"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -10849,6 +10912,11 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+statuses@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.0.tgz#aa7b107e018eb33e08e8aee2e7337e762dda1028"
+  integrity sha512-w9jNUUQdpuVoYqXxnyOakhckBbOxRaoYqJscyIBYCS5ixyCnO7nQn7zBZvP9zf5QOPZcz2DLUpE3KsNPbJBOFA==
+
 stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -12237,6 +12305,14 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.1:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
@@ -12270,3 +12346,20 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yargs@^15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"


### PR DESCRIPTION
Related issue: https://acme-climate.atlassian.net/browse/CR-270?atlOrigin=eyJpIjoiNDI2MGJiOWE1MjUzNGM1OGE2NDdlYTk3Y2VlZWNjZmQiLCJwIjoiaiJ9

This PR adds fixtures to reduce repeated code when declaring dummy objects in tests. It also adds mock-service-worker to replace mocking axios.

Currently, tests use a mocked out version of Axios, which returns predefined responses for the GET request. Some drawbacks of this method include:
- Redudant/repeated code including the need to chain axios calls based on the number of HTTP requests performed within a test(s)

- Per Kent C. Dodds
  - Mocking axios/fetch:
    - test is lacking is an assertion that the headers has a Content-Type of application/json
    - you end up re-implementing your entire backend... everywhere in your tests.
    - Ultimately, we have less confidence, a slower feedback loop, lots of duplicate code, or any combination of those.
  - The basic idea is this: create a mock server that intercepts all requests and handle it just like you would if it were a real server.

Resources
https://kentcdodds.com/blog/stop-mocking-fetch/
https://www.youtube.com/watch?v=v77fjkKQTH0

**Summary of Changes**
- Add msw package and related test directories
- Add server-handler, which handles tests HTTP requests and responses to API routes
- Add fixtures to seed test data
- Rename types FetchedFacets, AvailableFacets, SearchResult, and Citation to 'Raw' format
- Remove mockAxios references tests
- Update tests for 100% coverage and resolve act warnings
- Add env.ts file to instantiate env variables