### PR TITLE
Update github workflows to run all workflows on push to master

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,9 +3,6 @@ name: Back-end CI
 on:
   push:
     branches: [master]
-    paths:
-      - ".github/workflows/backend.yml"
-      - "backend/*"
   pull_request:
     branches: [master]
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,9 +6,6 @@ name: Front-end CI
 on:
   push:
     branches: [master]
-    paths:
-      - ".github/workflows/frontend.yml"
-      - "frontend/*"
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
This PR fixes triggering workflows whenever pushes are made to master. Originally, the intention was to run a specific workflow based on the directory where changes are made within the PR (mono-repo style). 

However, this seemed to override the behavior of running all workflows when pushing to master, regardless of which directory contains changes. Now workflows will always be triggered on master.