### PR TITLE
Pin isort version to <5

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -52,9 +52,12 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install Dependencies
+        # TODO: Remove explicit isort version after flake8-isort is updated to support v.5
+        # https://github.com/gforcada/flake8-isort/issues/88
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements/local.txt
+          pip install isort==4.3.21
 
       - name: Lint and Style (flake8, black)
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,8 @@ repos:
         language: python
         types: [python]
         args: ["--config=backend/setup.cfg"]
+        additional_dependencies:
+          - isort<5 # https://github.com/gforcada/flake8-isort/issues/88
 
   - repo: https://github.com/psf/black
     rev: stable


### PR DESCRIPTION
Related issue: https://github.com/gforcada/flake8-isort/issues/88

**Overview**
- flake-isort does not currently support v.5, revert after fix