### PR TITLE
Fix result count not rendering correctly due to default facet duplicates

### DIFF
--- a/backend/metagrid/projects/models.py
+++ b/backend/metagrid/projects/models.py
@@ -49,8 +49,6 @@ class Project(models.Model):
             "offset": 0,
             "limit": 0,
             "type": "Dataset",
-            "replica": False,
-            "latest": True,
             "format": "application/solr+json",
             "project": [self.name, self.name.upper(), self.name.lower()],
             "facets": ", ".join(facets),

--- a/frontend/src/components/Cart/SearchesCard.tsx
+++ b/frontend/src/components/Cart/SearchesCard.tsx
@@ -86,7 +86,9 @@ const SearchesCard: React.FC<Props> = ({
       <>
         <p>
           <span style={{ fontWeight: 'bold' }}>
-            {(data as { response: { numFound: number } }).response.numFound}
+            {(data as {
+              response: { numFound: number };
+            }).response.numFound.toLocaleString()}
           </span>{' '}
           results found for {project.name}
         </p>

--- a/frontend/src/components/Facets/FacetsForm.tsx
+++ b/frontend/src/components/Facets/FacetsForm.tsx
@@ -63,10 +63,7 @@ const FacetsForm: React.FC<Props> = ({
         <h4 style={styles.formTitle}>Default Facets</h4>
         <Form.Item name="selectedDefaults">
           <Checkbox.Group
-            options={[
-              { label: 'Latest Data', value: 'latest' },
-              { label: 'Include Replica', value: 'replica' },
-            ]}
+            options={[{ label: 'Include Replica', value: 'replica' }]}
           ></Checkbox.Group>
         </Form.Item>
         <h4 style={styles.formTitle}>Project Facets</h4>

--- a/frontend/src/components/Facets/index.tsx
+++ b/frontend/src/components/Facets/index.tsx
@@ -42,7 +42,7 @@ const Facets: React.FC<Props> = ({
   }): void => {
     const newActive = selectedFacets;
 
-    const newDefaults: DefaultFacets = { latest: false, replica: false };
+    const newDefaults: DefaultFacets = { latest: true, replica: false };
     const { selectedDefaults } = newActive;
     // Pop selectedDefaults key since that sets the state for defaultFacets separately
     delete newActive.selectedDefaults;

--- a/frontend/src/components/Search/index.tsx
+++ b/frontend/src/components/Search/index.tsx
@@ -243,7 +243,8 @@ const Search: React.FC<Props> = ({
         )}
         {isLoading && (
           <h3>
-            <span style={styles.resultsHeader}>Loading </span> results for{' '}
+            <span style={styles.resultsHeader}>Loading latest </span> results
+            for{' '}
             <span style={styles.resultsHeader}>
               {(activeProject as Project).name}
             </span>{' '}
@@ -254,7 +255,9 @@ const Search: React.FC<Props> = ({
         )}
         {results && !isLoading && (
           <h3>
-            <span style={styles.resultsHeader}>{numFound} </span>
+            <span style={styles.resultsHeader}>
+              {numFound.toLocaleString()}{' '}
+            </span>
             results found for{' '}
             <span style={styles.resultsHeader}>
               {(activeProject as Project).name}


### PR DESCRIPTION
**Related issue**
https://acme-climate.atlassian.net/browse/MG-322?atlOrigin=eyJpIjoiMTAzMDg4ZTkzMTk5NDAwNGI2NTIxMGQ3ZWQ0NzU1MmMiLCJwIjoiaiJ9

**Summary of Changes**
- Remove default facet as params in facets_url property of Project model
- Update FacetsForm to remove "latest" as a checkbox form field
- Update result count rendering using .toLocaleString()