### PR TITLE
Fix expiration of access tokens

### DIFF
--- a/backend/metagrid/config/base.py
+++ b/backend/metagrid/config/base.py
@@ -1,6 +1,7 @@
 """
 Base settings to build other settings files upon.
 """
+from datetime import timedelta
 from typing import List  # noqa
 
 import environ
@@ -238,6 +239,14 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "dj_rest_auth.jwt_auth.JWTCookieAuthentication",
     ),
+}
+
+# django-rest-framework-simplejwt
+# -------------------------------------------------------------------------------
+# https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html
+SIMPLE_JWT = {
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=14),
+    "ROTATE_REFRESH_TOKENS": True,
 }
 
 # django-allauth

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -38,6 +38,8 @@ describe('test fetchUserInfo()', () => {
 });
 describe('test AuthProvider', () => {
   it('renders using keycloak provider', async () => {
+    jest.useFakeTimers();
+
     const { getByTestId, getByText } = keycloakRender(
       <AuthProvider>
         <div data-testid="authProvider">
@@ -57,5 +59,8 @@ describe('test AuthProvider', () => {
     // Check children renders
     const renderResult = await waitFor(() => getByText('renders'));
     expect(renderResult).toBeTruthy();
+
+    jest.advanceTimersByTime(295000);
+    await waitFor(() => getByTestId('authProvider'));
   });
 });


### PR DESCRIPTION
**Related Issue**
https://acme-climate.atlassian.net/browse/MG-346?atlOrigin=eyJpIjoiMDVlM2M4ZmFlYTI2NDQ3YmJiOGM1OGM1NjVlNWJlNzAiLCJwIjoiaiJ9

**Overview**
This PR fixes the expiration of access tokens, which is caused by not retrieving fresh tokens before the access token expires on the server-side.

**Summary of Changes**
- Add call to runFetchUserAuth in intervals of approx 5 mins
- Add settings for django-rest-framework-simplejwt