### PR TITLE
Remove deprecated download services

### DIFF
--- a/frontend/src/api/mock/fixtures.ts
+++ b/frontend/src/api/mock/fixtures.ts
@@ -32,7 +32,7 @@ export const searchResultFixture = (
   const defaults: RawSearchResult = {
     id: 'foo',
     title: 'foo',
-    url: ['foo.bar'],
+    url: ['foo.bar|HTTPServer'],
     number_of_files: 3,
     data_node: 'node.gov',
     version: 1,

--- a/frontend/src/components/Search/FilesTable.test.tsx
+++ b/frontend/src/components/Search/FilesTable.test.tsx
@@ -6,7 +6,9 @@ import FilesTable, {
   genDownloadUrls,
   openDownloadUrl,
   DownloadUrls,
+  Props,
 } from './FilesTable';
+import { allowedDownloads } from './Table';
 import apiRoutes from '../../api/routes';
 import { server, rest } from '../../api/mock/setup-env';
 
@@ -19,10 +21,15 @@ describe('test genDownloadUrls()', () => {
   let urls: string[];
   let result: DownloadUrls;
   beforeEach(() => {
-    urls = ['http://test.com|HTTPServer', 'http://test.com|Globus'];
+    urls = [
+      'http://test.com|HTTPServer',
+      'http://test.com|Globus',
+      'http://test.com/file.html|OPENDAP',
+    ];
     result = [
       { downloadType: 'HTTPServer', downloadUrl: 'http://test.com' },
       { downloadType: 'Globus', downloadUrl: 'http://test.com' },
+      { downloadType: 'OPENDAP', downloadUrl: 'http://test.com/file.dods' },
     ];
   });
 
@@ -60,6 +67,11 @@ describe('test openDownloadUrl()', () => {
   });
 });
 
+const defaultProps: Props = {
+  id: 'id',
+  allowedDownloads,
+};
+
 describe('test FilesTable component', () => {
   it('returns Alert when there is an error fetching files', async () => {
     server.use(
@@ -68,7 +80,7 @@ describe('test FilesTable component', () => {
       })
     );
 
-    const { getByRole } = render(<FilesTable id="id" />);
+    const { getByRole } = render(<FilesTable {...defaultProps} />);
     const alertMsg = await waitFor(() =>
       getByRole('img', { name: 'close-circle', hidden: true })
     );
@@ -80,7 +92,7 @@ describe('test FilesTable component', () => {
     // https://stackoverflow.com/questions/58189851/mocking-a-conditional-window-open-function-call-with-jest
     Object.defineProperty(window, 'open', { value: jest.fn() });
 
-    const { getByRole, getByTestId } = render(<FilesTable id="id" />);
+    const { getByRole, getByTestId } = render(<FilesTable {...defaultProps} />);
 
     // Check files table componet renders
     const filesTableComponent = await waitFor(() => getByTestId('filesTable'));
@@ -89,7 +101,7 @@ describe('test FilesTable component', () => {
     // Select first cell row
     const firstRow = await waitFor(() =>
       getByRole('row', {
-        name: 'foo 1 Bytes foo.bar download',
+        name: 'foo 1 Bytes HTTPServer download',
       })
     );
     expect(firstRow).toBeTruthy();

--- a/frontend/src/components/Search/FilesTable.tsx
+++ b/frontend/src/components/Search/FilesTable.tsx
@@ -22,7 +22,11 @@ export const genDownloadUrls = (urls: string[]): DownloadUrls => {
   const newUrls: DownloadUrls = [];
   urls.forEach((url) => {
     const downloadType = url.split('|').pop();
-    const downloadUrl = parseUrl(url, '|');
+    let downloadUrl = parseUrl(url, '|');
+
+    if (downloadType === 'OPENDAP') {
+      downloadUrl = downloadUrl.replace('.html', '.dods');
+    }
     newUrls.push({ downloadType, downloadUrl });
   });
   return newUrls;
@@ -34,11 +38,12 @@ export const openDownloadUrl = (url: string): Window | null => {
   return window.open(url, '_blank');
 };
 
-type Props = {
+export type Props = {
   id: string;
+  allowedDownloads: ReadonlyArray<string>;
 };
 
-const FilesTable: React.FC<Props> = ({ id }) => {
+const FilesTable: React.FC<Props> = ({ id, allowedDownloads }) => {
   const { data, error, isLoading } = useAsync({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     promiseFn: (fetchFiles as unknown) as PromiseFn<Record<string, any>>,
@@ -90,7 +95,6 @@ const FilesTable: React.FC<Props> = ({ id }) => {
       width: 200,
       render: (record: { url: string[] }) => {
         const downloadUrls = genDownloadUrls(record.url);
-
         return (
           <span>
             <Form
@@ -101,14 +105,19 @@ const FilesTable: React.FC<Props> = ({ id }) => {
             >
               <Form.Item name="download">
                 <Select style={{ width: 120 }}>
-                  {downloadUrls.map((option) => (
-                    <Select.Option
-                      key={option.downloadType}
-                      value={option.downloadUrl as React.ReactText}
-                    >
-                      {option.downloadType}
-                    </Select.Option>
-                  ))}
+                  {downloadUrls.map(
+                    (option) =>
+                      allowedDownloads.includes(
+                        option.downloadType as string
+                      ) && (
+                        <Select.Option
+                          key={option.downloadType}
+                          value={option.downloadUrl as React.ReactText}
+                        >
+                          {option.downloadType}
+                        </Select.Option>
+                      )
+                  )}
                 </Select>
               </Form.Item>
               <Form.Item>

--- a/frontend/src/components/Search/Table.tsx
+++ b/frontend/src/components/Search/Table.tsx
@@ -29,6 +29,9 @@ export type Props = {
   handlePageSizeChange?: (size: number) => void;
 };
 
+// Allowed download types
+export const allowedDownloads = ['HTTPServer', 'OPENDAP', 'Globus'];
+
 const Table: React.FC<Props> = ({
   loading,
   results,
@@ -96,7 +99,10 @@ const Table: React.FC<Props> = ({
                 })}
               </Collapse.Panel>
               <Collapse.Panel header="Files" key="files">
-                <FilesTable id={record.id} />
+                <FilesTable
+                  id={record.id}
+                  allowedDownloads={allowedDownloads}
+                />
               </Collapse.Panel>
             </Collapse>
           </>
@@ -181,30 +187,36 @@ const Table: React.FC<Props> = ({
       title: 'Download',
       key: 'download',
       width: 200,
-      render: (record: RawSearchResult) => (
-        <span>
-          <Form layout="inline">
-            <Form.Item>
-              {/* eslint-disable-next-line react/prop-types */}
-              <Select defaultValue={record.access[0]} style={{ width: 120 }}>
-                {/* eslint-disable-next-line react/prop-types */}
-                {record.access.map((option) => (
-                  <Select.Option key={option} value={option}>
-                    {option}
-                  </Select.Option>
-                ))}
-              </Select>
-            </Form.Item>
-            <Form.Item>
-              <Button
-                type="primary"
-                icon={<DownloadOutlined />}
-                disabled
-              ></Button>
-            </Form.Item>
-          </Form>
-        </span>
-      ),
+      render: (record: RawSearchResult) => {
+        const availableDownloads = record.access.filter((download) =>
+          allowedDownloads.includes(download)
+        );
+        return (
+          <span>
+            <Form layout="inline">
+              <Form.Item>
+                <Select
+                  defaultValue={availableDownloads[0]}
+                  style={{ width: 120 }}
+                >
+                  {availableDownloads.map((option) => (
+                    <Select.Option key={option} value={option}>
+                      {option}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </Form.Item>
+              <Form.Item>
+                <Button
+                  type="primary"
+                  icon={<DownloadOutlined />}
+                  disabled
+                ></Button>
+              </Form.Item>
+            </Form>
+          </span>
+        );
+      },
     },
     {
       title: 'Additional',

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 
 import { fetchUserAuth, AuthProvider, fetchUserInfo } from './AuthContext';
 import apiRoutes from '../api/routes';
@@ -60,7 +60,13 @@ describe('test AuthProvider', () => {
     const renderResult = await waitFor(() => getByText('renders'));
     expect(renderResult).toBeTruthy();
 
-    jest.advanceTimersByTime(295000);
+    act(() => {
+      jest.advanceTimersByTime(295000);
+    });
+
     await waitFor(() => getByTestId('authProvider'));
+
+    // Revert back to real timer
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
**Related Issues**
- https://acme-climate.atlassian.net/browse/MG-351?atlOrigin=eyJpIjoiM2E3NDE0MDU2NmJjNDdhNGI0MzBkZTM2MDk0ZmI5MmIiLCJwIjoiaiJ9
- https://acme-climate.atlassian.net/browse/MG-366?atlOrigin=eyJpIjoiOTkxMjBiZDljMDYzNDBjZTk3YzljOWUwOWFlNDgyNWMiLCJwIjoiaiJ9

**Overview**
This PR removes deprecated download services (GridFTP and LAS) from rendering as download options.

**Summary of Changes**
- Update genDownloadUrls function to update OPENDAP link
- Fix act warning in AuthProvider test due to jest.advanceTimersByTime
- Add conditional in map for rendering downloads in FilesTable
- Add allowedDownloads as a prop for FilesTable
- Update searchResultFixture url field