### PR TITLE
Add wget script API integration for downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,5 +183,6 @@ Session.vim
 tags
 
 # Environment variable files
-**/.env
-**/.envs/
+.env
+.envs/*
+!.envs/.local/

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Finally, note that Keycloak is not included as a Docker service and must be a st
 
 ### 1. Back-end Configuration
 
-#### Django
+#### 1.1 Django
 
 Directory: `backend/.envs/.production/.django`
 
@@ -292,7 +292,7 @@ KEYCLOAK_CLIENT_ID=backend
 
 Directory: `frontend/.envs/.production/.react`
 
-#### API
+#### 2.1 MetaGrid API
 
 ##### `REACT_APP_API_PROTOCOL`
 
@@ -336,7 +336,23 @@ Example:
 REACT_APP_API_PORT=8000
 ```
 
-#### ESGF Search API
+#### 2.2 ESGF wget API
+
+[Documentation](https://github.com/ESGF/esgf-wget)
+
+##### `REACT_APP_WGET_API_URL`
+
+The URL for the ESGF wget API.
+
+Example:
+
+```env
+REACT_APP_WGET_API_URL=https://pcmdi8vm.llnl.gov/wget
+```
+
+#### 2.3 ESGF Search API
+
+[Documentation](https://github.com/ESGF/esgf.github.io/wiki/ESGF_Search_REST_API)
 
 ##### `REACT_APP_ESGF_NODE_PROTOCOL`
 
@@ -358,7 +374,7 @@ Example:
 REACT_APP_ESGF_NODE_URL=esgf-node.llnl.gov
 ```
 
-#### Keycloak
+#### 2.4 Keycloak
 
 ##### `REACT_APP_KEYCLOAK_REALM`
 

--- a/frontend/.envs/.local/.react
+++ b/frontend/.envs/.local/.react
@@ -5,7 +5,12 @@ REACT_APP_API_PROTOCOL=http://
 REACT_APP_API_URL=localhost
 REACT_APP_API_PORT=8000
 
-# ESG Search API
+# ESGF WGET API
+# ------------------------------------------------------------------------------
+# https://github.com/ESGF/esgf-wget
+REACT_APP_WGET_API_URL=https://pcmdi8vm.llnl.gov/wget
+
+# ESGF Search API
 # ------------------------------------------------------------------------------
 # https://esgf.github.io/esg-search/ESGF_Search_RESTful_API.html
 REACT_APP_ESGF_NODE_PROTOCOL=https://

--- a/frontend/.envs/.production/.react
+++ b/frontend/.envs/.production/.react
@@ -5,6 +5,11 @@ REACT_APP_API_PROTOCOL=http://
 REACT_APP_API_URL=localhost
 REACT_APP_API_PORT=8000
 
+# ESGF WGET API
+# ------------------------------------------------------------------------------
+# https://github.com/ESGF/esgf-wget
+REACT_APP_WGET_API_URL=https://pcmdi8vm.llnl.gov/wget
+
 # ESG Search API
 # ------------------------------------------------------------------------------
 # https://esgf.github.io/esg-search/ESGF_Search_RESTful_API.html

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -81,5 +81,5 @@ typings/
 src/react-app-env.d.ts
 
 # Environment variables
-.env
-.envs/*
+# .env
+# .envs/*

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -81,5 +81,6 @@ typings/
 src/react-app-env.d.ts
 
 # Environment variables
-# .env
-# .envs/*
+.env
+.envs/*
+!.envs/.local/

--- a/frontend/src/api/index.test.ts
+++ b/frontend/src/api/index.test.ts
@@ -8,6 +8,8 @@ import {
   fetchUserCart,
   fetchUserSearches,
   genUrlQuery,
+  fetchWgetScript,
+  openDownloadURL,
   processCitation,
   updateUserCart,
 } from '.';
@@ -316,5 +318,52 @@ describe('test deleteUserSearch', () => {
     );
 
     await expect(deleteUserSearch('pk', 'access_token')).rejects.toThrow('404');
+  });
+});
+
+describe('test fetchWgetScript', () => {
+  it('returns a response with a single dataset id', async () => {
+    await fetchWgetScript('id');
+  });
+  it('returns a response with an array of dataset ids', async () => {
+    await fetchWgetScript(['id', 'id']);
+  });
+
+  it('catches and throws an error', async () => {
+    server.use(
+      rest.get(apiRoutes.wget, (_req, res, ctx) => {
+        return res(ctx.status(404));
+      })
+    );
+
+    await expect(fetchWgetScript('id')).rejects.toThrow('404');
+  });
+});
+
+describe('test openDownloadUrl()', () => {
+  let windowSpy: jest.SpyInstance;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockedOpen: jest.Mock<any, any>;
+
+  beforeEach(() => {
+    mockedOpen = jest.fn();
+    windowSpy = jest.spyOn(global, 'window', 'get');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  it('should return https://example.com', () => {
+    const url = 'https://example.com';
+    windowSpy.mockImplementation(() => ({
+      location: {
+        origin: url,
+      },
+      open: mockedOpen,
+    }));
+
+    openDownloadURL(url);
+    expect(window.location.origin).toEqual('https://example.com');
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -343,3 +343,43 @@ Promise<{ [key: string]: any }> => {
       throw new Error(error);
     });
 };
+
+/**
+ * Performs validation against the wget API to ensure a 200 response.
+ *
+ * If the API returns a 200, it returns the responseURL so the browser can open
+ * the link.
+ */
+export const fetchWgetScript = async (
+  ids: string[] | string
+): Promise<string> => {
+  const params = new URLSearchParams();
+
+  if (Array.isArray(ids)) {
+    ids.forEach((id: string) => {
+      params.append('dataset_id', id);
+    });
+  } else {
+    params.append('dataset_id', ids);
+  }
+
+  return axios
+    .get(apiRoutes.wget, { params })
+    .then((res) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      return res.request.responseURL as string;
+    })
+    .catch((error) => {
+      throw new Error(error);
+    });
+};
+
+/**
+ * Sets the window location href to the specified URL.
+ *
+ * It removes the proxyString from the URL so the link can be access through
+ * the browser.
+ */
+export const openDownloadURL = (url: string): void => {
+  window.location.href = url.replace(`${proxyString}/`, '');
+};

--- a/frontend/src/api/mock/fixtures.ts
+++ b/frontend/src/api/mock/fixtures.ts
@@ -37,7 +37,7 @@ export const searchResultFixture = (
     data_node: 'node.gov',
     version: 1,
     size: 1,
-    access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
+    access: ['HTTPServer', 'OPeNDAP', 'Globus'],
     citation_url: ['https://foo.bar'],
   };
   return { ...defaults, ...props };
@@ -46,7 +46,12 @@ export const searchResultFixture = (
 export const searchResultsFixture = (): RawSearchResult[] => {
   return [
     searchResultFixture(),
-    searchResultFixture({ id: 'bar', title: 'bar', number_of_files: 2 }),
+    searchResultFixture({
+      id: 'bar',
+      title: 'bar',
+      number_of_files: 2,
+      access: ['HTTPServer', 'OPeNDAP'],
+    }),
   ];
 };
 
@@ -84,7 +89,7 @@ export const parsedFacetsFixture = (
  * Cart fixture, which contains multiple search results.
  */
 export const cartFixture = (): Cart => {
-  return [searchResultFixture(), searchResultFixture()];
+  return searchResultsFixture();
 };
 
 /**

--- a/frontend/src/api/mock/server-handlers.ts
+++ b/frontend/src/api/mock/server-handlers.ts
@@ -51,6 +51,9 @@ const handlers = [
   rest.get(apiRoutes.citation, (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json(citationFixture()));
   }),
+  rest.get(apiRoutes.wget, (_req, res, ctx) => {
+    return res(ctx.status(200));
+  }),
   // Default fallback handler
   rest.get('*', (req, res, ctx) => {
     // eslint-disable-next-line no-console

--- a/frontend/src/api/routes.ts
+++ b/frontend/src/api/routes.ts
@@ -8,7 +8,13 @@
  * https://github.com/ESGF/esgf.github.io/wiki/ESGF_Search_REST_API
  *
  */
-import { apiBaseUrl, nodeRoute, nodeUrl, proxyString } from '../env';
+import {
+  apiBaseUrl,
+  nodeRoute,
+  nodeUrl,
+  proxyString,
+  wgetApiUrl,
+} from '../env';
 
 type ApiRoutes = {
   keycloakAuth: string;
@@ -20,6 +26,7 @@ type ApiRoutes = {
   esgfDatasets: string;
   esgfFiles: string;
   citation: string;
+  wget: string;
 };
 
 /**
@@ -46,6 +53,8 @@ const apiRoutes: ApiRoutes = {
   esgfFiles: `${proxyString}/${nodeRoute}/search_files/:id/${nodeUrl}/`,
   // ESGF Citation API (uses dummy link)
   citation: `${proxyString}/citation_url`,
+  // ESGF wget API
+  wget: `${proxyString}/${wgetApiUrl}`,
 };
 
 export default apiRoutes;

--- a/frontend/src/components/App/App.test.tsx
+++ b/frontend/src/components/App/App.test.tsx
@@ -355,7 +355,8 @@ describe('User cart', () => {
     // Check first row exists
     const firstRow = await waitFor(() =>
       getByRole('row', {
-        name: 'right-circle foo 3 1 Bytes node.gov 1 WGET download plus',
+        name:
+          'right-circle foo 3 1 Bytes node.gov 1 check-circle Globus Compatible wget download plus',
       })
     );
     expect(firstRow).toBeTruthy();
@@ -491,7 +492,8 @@ describe('User cart', () => {
     // Check first row exists
     const firstRow = await waitFor(() =>
       getByRole('row', {
-        name: 'right-circle foo 3 1 Bytes node.gov 1 WGET download plus',
+        name:
+          'right-circle foo 3 1 Bytes node.gov 1 check-circle Globus Compatible wget download plus',
       })
     );
     expect(firstRow).toBeTruthy();
@@ -559,7 +561,8 @@ describe('User cart', () => {
     // Check first row exists
     const firstRow = await waitFor(() =>
       getByRole('row', {
-        name: 'right-circle foo 3 1 Bytes node.gov 1 WGET download plus',
+        name:
+          'right-circle foo 3 1 Bytes node.gov 1 check-circle Globus Compatible wget download plus',
       })
     );
     expect(firstRow).toBeTruthy();

--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -230,7 +230,7 @@ const App: React.FC = () => {
   const handleClearCart = (): void => {
     setCart([]);
 
-    /* instanbul ignore else */
+    /* instabul ignore else */
     if (isAuthenticated) {
       void updateUserCart(pk as string, accessToken as string, []);
     }

--- a/frontend/src/components/Cart/Items.test.tsx
+++ b/frontend/src/components/Cart/Items.test.tsx
@@ -1,30 +1,14 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, within, waitFor } from '@testing-library/react';
 
 import Items, { Props } from './Items';
+import apiRoutes from '../../api/routes';
+import { cartFixture } from '../../api/mock/fixtures';
+import { rest, server } from '../../api/mock/setup-env';
 
 const defaultProps: Props = {
-  cart: [
-    {
-      id: 'foo',
-      url: ['foo.bar'],
-      number_of_files: 3,
-      data_node: 'node.gov',
-      version: 1,
-      size: 1,
-      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
-    },
-    {
-      id: 'bar',
-      url: ['foo.bar'],
-      number_of_files: 2,
-      data_node: 'node.gov',
-      size: 1,
-      version: 1,
-      access: ['HTTPServer', 'GridFTP', 'OPENDAP', 'Globus'],
-    },
-  ],
+  cart: cartFixture(),
   handleCart: jest.fn(),
   clearCart: jest.fn(),
 };
@@ -53,4 +37,77 @@ it('removes all items from the cart when confirming the popconfirm', () => {
   // Submit the popover
   const submitPopOverBtn = getByText('OK');
   fireEvent.click(submitPopOverBtn);
+});
+
+it('handles selecting items in the cart and downloading them via wget', async () => {
+  const { getByRole, getByTestId } = render(<Items {...defaultProps} />);
+
+  // Check first row renders and click the checkbox
+  const firstRow = getByRole('row', {
+    name:
+      'right-circle foo 3 1 Bytes node.gov 1 check-circle Globus Compatible wget download minus',
+  });
+  const firstCheckBox = within(firstRow).getByRole('checkbox');
+  expect(firstCheckBox).toBeTruthy();
+  fireEvent.click(firstCheckBox);
+
+  // Check download form renders
+  const downloadForm = getByTestId('downloadForm');
+  expect(downloadForm).toBeTruthy();
+
+  // Check download button exists and submit the form
+  const downloadBtn = within(downloadForm).getByRole('img', {
+    name: 'download',
+  });
+  expect(downloadBtn).toBeTruthy();
+  fireEvent.submit(downloadBtn);
+
+  // Check cart items component renders
+  const cartItemsComponent = await waitFor(() => getByTestId('cartItems'));
+  expect(cartItemsComponent).toBeTruthy();
+});
+
+it('handles error selecting items in the cart and downloading them via wget', async () => {
+  // Override route HTTP response
+  server.use(
+    rest.get(apiRoutes.wget, (_req, res, ctx) => {
+      return res(ctx.status(404));
+    })
+  );
+
+  const { getByRole, getByTestId, getByText } = render(
+    <Items {...defaultProps} />
+  );
+
+  // Check first row renders and click the checkbox
+  const firstRow = getByRole('row', {
+    name:
+      'right-circle foo 3 1 Bytes node.gov 1 check-circle Globus Compatible wget download minus',
+  });
+  const firstCheckBox = within(firstRow).getByRole('checkbox');
+  expect(firstCheckBox).toBeTruthy();
+  fireEvent.click(firstCheckBox);
+
+  // Check download form renders
+  const downloadForm = getByTestId('downloadForm');
+  expect(downloadForm).toBeTruthy();
+
+  // Check download button exists and submit the form
+  const downloadBtn = within(downloadForm).getByRole('img', {
+    name: 'download',
+  });
+  expect(downloadBtn).toBeTruthy();
+  fireEvent.submit(downloadBtn);
+
+  // Check cart items component renders
+  const cartItemsComponent = await waitFor(() => getByTestId('cartItems'));
+  expect(cartItemsComponent).toBeTruthy();
+
+  // Check error message renders
+  const errorMsg = await waitFor(() =>
+    getByText(
+      'There was an issue fetching the wget script. Please contact support or try again later.'
+    )
+  );
+  expect(errorMsg).toBeTruthy();
 });

--- a/frontend/src/components/Cart/Items.tsx
+++ b/frontend/src/components/Cart/Items.tsx
@@ -1,8 +1,11 @@
+import {
+  CloudDownloadOutlined,
+  DownloadOutlined,
+  QuestionCircleOutlined,
+} from '@ant-design/icons';
+import { Col, Form, message, Row, Select } from 'antd';
 import React from 'react';
-
-import { Col, Row } from 'antd';
-import { QuestionCircleOutlined } from '@ant-design/icons';
-
+import { fetchWgetScript, openDownloadURL } from '../../api/index';
 import Empty from '../DataDisplay/Empty';
 import Popconfirm from '../Feedback/Popconfirm';
 import Button from '../General/Button';
@@ -18,6 +21,7 @@ const styles = {
       display: 'flex',
     } as React.CSSProperties,
   },
+  image: { margin: '1em', width: '25%' },
 };
 
 export type Props = {
@@ -27,8 +31,48 @@ export type Props = {
 };
 
 const Items: React.FC<Props> = ({ cart, handleCart, clearCart }) => {
+  const [form] = Form.useForm();
+
+  // TODO: Add 'Globus' as a download option
+  // Available download options for datasets (batch download of files)
+  const downloadOptions = ['wget'];
+
+  // Items selected in the data table
+  const [selectedItems, setSelectedItems] = React.useState<
+    RawSearchResult[] | []
+  >([]);
+
+  /**
+   * Handles when the user selects datasets for download
+   */
+  const handleSelect = (selectedRows: RawSearchResult[] | []): void => {
+    setSelectedItems(selectedRows);
+  };
+
+  /**
+   * Handles the download form
+   * TODO: Add handle for Globus
+   */
+  const handleDownloadForm = (downloadType: 'wget' | 'Globus'): void => {
+    /* istanbul ignore else */
+    if (downloadType === 'wget') {
+      const ids = (selectedItems as RawSearchResult[]).map((item) => item.id);
+      fetchWgetScript(ids)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .then((url) => {
+          openDownloadURL(url);
+        })
+        .catch(() => {
+          // eslint-disable-next-line no-void
+          void message.error(
+            'There was an issue fetching the wget script. Please contact support or try again later.'
+          );
+        });
+    }
+  };
+
   return (
-    <>
+    <div data-testid="cartItems">
       {cart.length === 0 && <Empty description="Your cart is empty"></Empty>}
       {cart.length > 0 && (
         <>
@@ -51,12 +95,51 @@ const Items: React.FC<Props> = ({ cart, handleCart, clearCart }) => {
                 results={cart}
                 cart={cart}
                 handleCart={handleCart}
+                handleRowSelect={handleSelect}
               />
             </Col>
           </Row>
+          <div data-testid="downloadForm">
+            <h1>
+              <CloudDownloadOutlined /> Download Your Cart
+            </h1>
+            <p></p>
+            <p>
+              Select datasets in your cart and confirm your download preference.
+              Speeds will vary based on your bandwidth and distance from the
+              data node serving the files.
+            </p>
+            <Form
+              form={form}
+              layout="inline"
+              onFinish={({ downloadType }) => handleDownloadForm(downloadType)}
+              initialValues={{
+                downloadType: downloadOptions[0],
+              }}
+            >
+              <Form.Item name="downloadType">
+                <Select style={{ width: 235 }}>
+                  {downloadOptions.map((option) => (
+                    <Select.Option key={option} value={option}>
+                      {option}
+                    </Select.Option>
+                  ))}
+                  /
+                </Select>
+              </Form.Item>
+              <Form.Item>
+                <Button
+                  type="primary"
+                  htmlType="submit"
+                  icon={<DownloadOutlined />}
+                  disabled={selectedItems.length === 0}
+                ></Button>
+              </Form.Item>
+            </Form>
+          </div>
         </>
       )}
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/components/Cart/Summary.test.tsx
+++ b/frontend/src/components/Cart/Summary.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import Summary, { Props } from './Summary';
 import { cartFixture } from '../../api/mock/fixtures';
@@ -30,19 +30,6 @@ it('shows the correct number of datasets and files', () => {
     getByText((_, node) => node.textContent === 'Number of Datasets: 2')
   ).toBeTruthy();
   expect(
-    getByText((_, node) => node.textContent === 'Number of Files: 6')
+    getByText((_, node) => node.textContent === 'Number of Files: 5')
   ).toBeTruthy();
-});
-
-it('handles the download form submission with handleOnFinish()', () => {
-  const { getByRole } = render(
-    <Router>
-      <Summary {...defaultProps} />
-    </Router>
-  );
-
-  // Check download button renders and click it
-  const downloadBtn = getByRole('img', { name: 'download' });
-  expect(downloadBtn).toBeTruthy();
-  fireEvent.submit(downloadBtn);
 });

--- a/frontend/src/components/Cart/Summary.tsx
+++ b/frontend/src/components/Cart/Summary.tsx
@@ -1,13 +1,8 @@
+import { Divider } from 'antd';
 import React from 'react';
-import { Divider, Form, Select } from 'antd';
-import { DownloadOutlined } from '@ant-design/icons';
-
-import Button from '../General/Button';
-import { formatBytes } from '../../utils/utils';
-
 import cartImg from '../../assets/img/cart.svg';
-import dataImg from '../../assets/img/data.svg';
 import folderImg from '../../assets/img/folder.svg';
+import { formatBytes } from '../../utils/utils';
 
 const styles = {
   headerContainer: { display: 'flex', justifyContent: 'center' },
@@ -24,10 +19,6 @@ export type Props = {
 };
 
 const Summary: React.FC<Props> = ({ cart }) => {
-  const [form] = Form.useForm();
-  // TODO: Add handle for Globus download if selected dataset has no Globus option
-  const downloadOptions = ['WGET', 'Globus'];
-
   let numFiles = 0;
   let totalDataSize = '0';
   if (cart.length > 0) {
@@ -63,40 +54,6 @@ const Summary: React.FC<Props> = ({ cart }) => {
         Total File Size: <span style={styles.statistic}>{totalDataSize}</span>
       </h1>
       <Divider />
-      <div style={styles.headerContainer}>
-        <img style={styles.image} src={dataImg as string} alt="Data" />
-      </div>
-      <h1 style={styles.summaryHeader}>Download Your Cart</h1>
-      <p>
-        Download speeds will vary based on your bandwidth and distance from the
-        data node serving the file(s)
-      </p>
-      <Form
-        form={form}
-        layout="inline"
-        initialValues={{
-          download: downloadOptions[0],
-        }}
-      >
-        <Form.Item name="download">
-          <Select style={{ width: 235 }}>
-            {downloadOptions.map((option) => (
-              <Select.Option key={option} value={option}>
-                {option}
-              </Select.Option>
-            ))}
-            /
-          </Select>
-        </Form.Item>
-        <Form.Item>
-          <Button
-            type="primary"
-            htmlType="submit"
-            icon={<DownloadOutlined />}
-            disabled
-          ></Button>
-        </Form.Item>
-      </Form>
     </div>
   );
 };

--- a/frontend/src/components/Search/FilesTable.test.tsx
+++ b/frontend/src/components/Search/FilesTable.test.tsx
@@ -2,12 +2,7 @@
 import React from 'react';
 import { render, waitFor, fireEvent, within } from '@testing-library/react';
 
-import FilesTable, {
-  genDownloadUrls,
-  openDownloadUrl,
-  DownloadUrls,
-  Props,
-} from './FilesTable';
+import FilesTable, { genDownloadUrls, DownloadUrls, Props } from './FilesTable';
 import apiRoutes from '../../api/routes';
 import { server, rest } from '../../api/mock/setup-env';
 
@@ -38,34 +33,6 @@ describe('test genDownloadUrls()', () => {
   });
 });
 
-describe('test openDownloadUrl()', () => {
-  let windowSpy: jest.SpyInstance;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockedOpen: jest.Mock<any, any>;
-
-  beforeEach(() => {
-    mockedOpen = jest.fn();
-    windowSpy = jest.spyOn(global, 'window', 'get');
-  });
-
-  afterEach(() => {
-    windowSpy.mockRestore();
-  });
-
-  it('should return https://example.com', () => {
-    const url = 'https://example.com';
-    windowSpy.mockImplementation(() => ({
-      location: {
-        origin: url,
-      },
-      open: mockedOpen,
-    }));
-
-    openDownloadUrl(url);
-    expect(window.location.origin).toEqual('https://example.com');
-  });
-});
-
 const defaultProps: Props = {
   id: 'id',
 };
@@ -88,8 +55,11 @@ describe('test FilesTable component', () => {
   it('renders files table with data and opens up a new window when submitting form for downloading a file', async () => {
     // Update the value of open
     // https://stackoverflow.com/questions/58189851/mocking-a-conditional-window-open-function-call-with-jest
-    Object.defineProperty(window, 'open', { value: jest.fn() });
-
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: jest.fn(),
+      },
+    });
     const { getByRole, getByTestId } = render(<FilesTable {...defaultProps} />);
 
     // Check files table componet renders

--- a/frontend/src/components/Search/FilesTable.tsx
+++ b/frontend/src/components/Search/FilesTable.tsx
@@ -7,7 +7,7 @@ import { Form, Select, Table as TableD } from 'antd';
 import Alert from '../Feedback/Alert';
 import Button from '../General/Button';
 
-import { fetchFiles } from '../../api';
+import { fetchFiles, openDownloadURL } from '../../api';
 import { parseUrl, formatBytes } from '../../utils/utils';
 
 export type DownloadUrls = {
@@ -31,13 +31,6 @@ export const genDownloadUrls = (urls: string[]): DownloadUrls => {
   });
   return newUrls;
 };
-/**
- * Opens the selected download url in a new tab
- */
-export const openDownloadUrl = (url: string): Window | null => {
-  return window.open(url, '_blank');
-};
-
 export type Props = {
   id: string;
 };
@@ -102,7 +95,7 @@ const FilesTable: React.FC<Props> = ({ id }) => {
             <Form
               data-testid="download-form"
               layout="inline"
-              onFinish={({ download }) => openDownloadUrl(download)}
+              onFinish={({ download }) => openDownloadURL(download)}
               initialValues={{ download: downloadUrls[0].downloadUrl }}
             >
               <Form.Item name="download">

--- a/frontend/src/components/Search/index.test.tsx
+++ b/frontend/src/components/Search/index.test.tsx
@@ -216,7 +216,8 @@ describe('test Search component', () => {
 
     // Select the first row
     const firstRow = getByRole('row', {
-      name: 'right-circle foo 3 1 Bytes node.gov 1 WGET download plus',
+      name:
+        'right-circle foo 3 1 Bytes node.gov 1 check-circle Globus Compatible wget download plus',
     });
     expect(firstRow).toBeTruthy();
 

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -9,6 +9,9 @@ const apiUrl = process.env.REACT_APP_API_URL as string;
 const apiPort = process.env.REACT_APP_API_PORT as string;
 export const apiBaseUrl = `${apiProtocol}${apiUrl}:${apiPort}`;
 
+// wget Script API
+export const wgetApiUrl = process.env.REACT_APP_WGET_API_URL as string;
+
 // ESG Search API
 // ------------------------------------------------------------------------------
 // https://esgf.github.io/esg-search/ESGF_Search_RESTful_API.html


### PR DESCRIPTION
**Related Issues**
- https://acme-climate.atlassian.net/browse/MG-393?atlOrigin=eyJpIjoiNjM4ZTE4NmU5N2RmNDA5ZDlkMmZiY2ExYmY2ZjgxYWIiLCJwIjoiaiJ9

**Overview**
This PR integrates the wget script api for downloading datasets.

**Summary of Changes**
- Add env variable `REACT_APP_WGET_API_URL`
- Add server-handlers, routes, and update fixtures for wget script api

`api`
- Add `fetchWgetScript`and `openDownloadURL` functions

`Table`
- Add check for Globus compatibility
  - Update tests to reflect change
- Add function `handleDownloadForm`
- Remove check for disabling the selection of rows

`Items`
- Add `handleDownloadForm` function
- Add form for downloading selected items

`FilesTable`
- Remove `openDownloadUrl` function

`Summary`
- Remove form for downloading