### PR TITLE
Add packageRules to ignore eslint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,11 @@
       "requirements/local.txt",
       "requirements/production.txt"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "packagePatterns": ["^eslint"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds `packageRules` to ignore `eslint` since updating to new major versions can break compatibility with existing packages (e.g. `react-scripts`).

Specifically, upgrading to `eslint` v.7.x breaks compatibility with `react-scripts` 3.x.

Related Issues:
- https://github.com/facebook/create-react-app/pull/8978