### PR TITLE
Fix missing dotenv package for proxy service

### DIFF
--- a/frontend/docker/local/proxy/Dockerfile
+++ b/frontend/docker/local/proxy/Dockerfile
@@ -7,14 +7,15 @@ WORKDIR /app
 # Add `/app/node_modules/.bin` to $PATH
 ENV PATH /app/node_modules/.bin:$PATH
 
-# Install app dependencies
+# Install proxy dependencies
 COPY package.json ./
 COPY yarn.lock ./
+RUN yarn add dotenv@^8.2.0
 RUN yarn add cors-anywhere
 
-# Add app
+# Add proxy
 COPY . ./
 COPY proxy.js ./
 
-# Start app
+# Start proxy
 CMD ["node", "proxy.js"]

--- a/frontend/src/api/mock/server-handlers.ts
+++ b/frontend/src/api/mock/server-handlers.ts
@@ -19,43 +19,37 @@ import {
 
 const handlers = [
   rest.post(apiRoutes.keycloakAuth, (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(userAuthFixture() as unknown));
+    return res(ctx.status(200), ctx.json(userAuthFixture()));
   }),
   rest.get(apiRoutes.userInfo, (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(userInfoFixture() as unknown));
+    return res(ctx.status(200), ctx.json(userInfoFixture()));
   }),
   rest.get(apiRoutes.userCart, (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(userCartFixture() as unknown));
+    return res(ctx.status(200), ctx.json(userCartFixture()));
   }),
   rest.patch(apiRoutes.userCart, (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(userCartFixture() as unknown));
+    return res(ctx.status(200), ctx.json(userCartFixture()));
   }),
   rest.get(apiRoutes.userSearches, (_req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({ results: savedSearchesFixture() } as unknown)
-    );
+    return res(ctx.status(200), ctx.json({ results: savedSearchesFixture() }));
   }),
   rest.post(apiRoutes.userSearches, (_req, res, ctx) => {
-    return res(ctx.status(201), ctx.json(savedSearchFixture() as unknown));
+    return res(ctx.status(201), ctx.json(savedSearchFixture()));
   }),
   rest.delete(apiRoutes.userSearch, (_req, res, ctx) => {
     return res(ctx.status(204));
   }),
   rest.get(apiRoutes.projects, (_req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({ results: projectsFixture() } as unknown)
-    );
+    return res(ctx.status(200), ctx.json({ results: projectsFixture() }));
   }),
   rest.get(apiRoutes.esgfDatasets, (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(esgSearchApiFixture() as unknown));
+    return res(ctx.status(200), ctx.json(esgSearchApiFixture()));
   }),
   rest.get(apiRoutes.esgfFiles, (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(esgSearchApiFixture() as unknown));
+    return res(ctx.status(200), ctx.json(esgSearchApiFixture()));
   }),
   rest.get(apiRoutes.citation, (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(citationFixture() as unknown));
+    return res(ctx.status(200), ctx.json(citationFixture()));
   }),
   rest.get(apiRoutes.wget, (_req, res, ctx) => {
     return res(ctx.status(200));
@@ -66,7 +60,7 @@ const handlers = [
     console.error(`Please add request handler for ${req.url.toString()}`);
     return res(
       ctx.status(500),
-      ctx.json({ error: 'You must add request handler.' } as unknown)
+      ctx.json({ error: 'You must add request handler.' })
     );
   }),
 ];


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR fixes the docker build for the front-end, specifically the `proxy` service. The `dotenv` package was missing from the service's dependencies.

It also removes unnecessary type casting in the server-handlers response section.

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [x] Linters
- [x] Existing test suite

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
