### PR TITLE
Fix incorrect dataset files URL

### DIFF
--- a/frontend/src/api/index.test.ts
+++ b/frontend/src/api/index.test.ts
@@ -1,14 +1,14 @@
 import {
   addUserSearchQuery,
   deleteUserSearchQuery,
-  fetchCitation,
-  fetchFiles,
+  fetchDatasetCitation,
+  fetchDatasetFiles,
   fetchProjects,
-  fetchResults,
+  fetchSearchResults,
   fetchUserCart,
-  fetchUserSearches,
+  fetchUserSearchQueries,
   fetchWgetScript,
-  genUrlQuery,
+  generateSearchURLQuery,
   openDownloadURL,
   processCitation,
   updateUserCart,
@@ -68,7 +68,7 @@ describe('test genUrlQuery()', () => {
       pageSize: 10,
     };
 
-    const url = genUrlQuery(
+    const url = generateSearchURLQuery(
       baseUrl,
       defaultFacets,
       activeFacets,
@@ -86,7 +86,7 @@ describe('test genUrlQuery()', () => {
       pageSize: 100,
     };
 
-    const url = genUrlQuery(
+    const url = generateSearchURLQuery(
       baseUrl,
       defaultFacets,
       activeFacets,
@@ -103,7 +103,7 @@ describe('test genUrlQuery()', () => {
       pageSize: 10,
     };
 
-    const url = genUrlQuery(
+    const url = generateSearchURLQuery(
       baseUrl,
       defaultFacets,
       activeFacets,
@@ -121,7 +121,13 @@ describe('test genUrlQuery()', () => {
       pageSize: 10,
     };
 
-    const url = genUrlQuery(baseUrl, defaultFacets, {}, textInputs, pagination);
+    const url = generateSearchURLQuery(
+      baseUrl,
+      defaultFacets,
+      {},
+      textInputs,
+      pagination
+    );
     expect(url).toEqual(
       `${apiRoutes.esgfDatasets}?limit=10&offset=0&latest=true&replica=false&query=input1,input2&`
     );
@@ -137,14 +143,14 @@ describe('test fetchResults()', () => {
   it('returns results', async () => {
     reqUrl += '?query=input1,input2&facet1=var1,var2&facet2=var3,var4';
 
-    const projects = await fetchResults([reqUrl]);
+    const projects = await fetchSearchResults([reqUrl]);
     expect(projects).toEqual(ESGFSearchAPIFixture());
   });
 
   it('returns results without free-text', async () => {
     reqUrl += '?query=*&facet1=var1,var2&facet2=var3,var4';
 
-    const projects = await fetchResults({ reqUrl });
+    const projects = await fetchSearchResults({ reqUrl });
     expect(projects).toEqual(ESGFSearchAPIFixture());
   });
   it('catches and throws an error', async () => {
@@ -153,7 +159,7 @@ describe('test fetchResults()', () => {
         return res(ctx.status(404));
       })
     );
-    await expect(fetchResults([reqUrl])).rejects.toThrow('404');
+    await expect(fetchSearchResults([reqUrl])).rejects.toThrow('404');
   });
 });
 
@@ -188,7 +194,7 @@ describe('test fetchCitation()', () => {
       creatorsList: 'Bob; Tom',
     };
 
-    const newCitation = await fetchCitation({
+    const newCitation = await fetchDatasetCitation({
       url: 'citation_url',
     });
     expect(newCitation).toEqual(results);
@@ -201,7 +207,7 @@ describe('test fetchCitation()', () => {
     );
 
     await expect(
-      fetchCitation({
+      fetchDatasetCitation({
         url: 'citation_url',
       })
     ).rejects.toThrow('404');
@@ -211,11 +217,11 @@ describe('test fetchCitation()', () => {
 describe('test fetchFiles()', () => {
   let dataset: { [key: string]: string };
   beforeEach(() => {
-    dataset = { id: 'testid' };
+    dataset = { id: 'testid|node.org' };
   });
 
   it('calls axios and returns files', async () => {
-    const files = await fetchFiles({ id: dataset.id });
+    const files = await fetchDatasetFiles({ id: dataset.id });
     expect(files).toEqual(ESGFSearchAPIFixture());
   });
   it('catches and throws an error', async () => {
@@ -224,7 +230,7 @@ describe('test fetchFiles()', () => {
         return res(ctx.status(404));
       })
     );
-    await expect(fetchFiles({ id: dataset.id })).rejects.toThrow('404');
+    await expect(fetchDatasetFiles({ id: dataset.id })).rejects.toThrow('404');
   });
 });
 
@@ -262,7 +268,7 @@ describe('test fetchUserCart', () => {
 
 describe('test fetchUserSearches', () => {
   it('returns user"s searches', async () => {
-    const res = await fetchUserSearches('access_token');
+    const res = await fetchUserSearchQueries('access_token');
 
     expect(res).toEqual({ results: userSearchQueriesFixture() });
   });
@@ -273,7 +279,7 @@ describe('test fetchUserSearches', () => {
       })
     );
 
-    await expect(fetchUserSearches('access_token')).rejects.toThrow('404');
+    await expect(fetchUserSearchQueries('access_token')).rejects.toThrow('404');
   });
 });
 

--- a/frontend/src/api/routes.ts
+++ b/frontend/src/api/routes.ts
@@ -8,13 +8,7 @@
  * https://github.com/ESGF/esgf.github.io/wiki/ESGF_Search_REST_API
  *
  */
-import {
-  esgfNodeURL,
-  esgfNodeURLNoProtocol,
-  metagridApiURL,
-  proxyURL,
-  wgetApiURL,
-} from '../env';
+import { esgfNodeURL, metagridApiURL, proxyURL, wgetApiURL } from '../env';
 
 type ApiRoutes = {
   keycloakAuth: string;
@@ -37,6 +31,8 @@ export const clickableRoute = (route: string): string => {
   return route.replace(`${proxyURL}/`, '');
 };
 
+// Any path with parameters (e.g. '/:datasetID/') must be in camelCase
+// https://mswjs.io/docs/basics/path-matching#path-with-parameters
 const apiRoutes: ApiRoutes = {
   // MetaGrid APIs
   keycloakAuth: `${metagridApiURL}/dj-rest-auth/keycloak`,
@@ -48,8 +44,7 @@ const apiRoutes: ApiRoutes = {
   // ESGF Search API - datasets
   esgfDatasets: `${proxyURL}/${esgfNodeURL}/esg-search/search/`,
   // ESGF Search API - files
-  // TODO: Fix route to use the correct suffix url for the node
-  esgfFiles: `${proxyURL}/${esgfNodeURL}/search_files/:id/${esgfNodeURLNoProtocol}/`,
+  esgfFiles: `${proxyURL}/${esgfNodeURL}/search_files/:datasetID/:sourceNode/`,
   // ESGF Citation API (uses dummy link)
   citation: `${proxyURL}/citation_url`,
   // ESGF wget API

--- a/frontend/src/common/utils.test.ts
+++ b/frontend/src/common/utils.test.ts
@@ -1,6 +1,5 @@
 import {
   formatBytes,
-  humanizeStr,
   objectHasKey,
   objectIsEmpty,
   shallowCompareObjects,
@@ -14,20 +13,6 @@ describe('Test objectIsEmpty', () => {
   it('returns false with non-empty object', () => {
     const testObj = { key1: 1, key2: 2 };
     expect(objectIsEmpty(testObj)).toBeFalsy();
-  });
-});
-
-describe('Test humanizeStr', () => {
-  it('removes underscore and lowercases', () => {
-    expect(humanizeStr('camel_case')).toEqual('Camel Case');
-  });
-
-  it('does not change properly formatted text ', () => {
-    expect(humanizeStr('Proper Text')).toEqual('Proper Text');
-  });
-
-  it('converts acronyms to uppercase', () => {
-    expect(humanizeStr('facet_id')).toEqual('Facet ID');
   });
 });
 

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -18,30 +18,17 @@ export const objectHasKey = (
 };
 
 /**
- * Converts strings from snake_case to human readable.
- *
- * It checks for acronyms to convert to uppercase.
- */
-export const humanizeStr = (str: string): string => {
-  const acronyms = ['Id', 'Cf', 'Cmor', 'Mip'];
-  const frags = str.split('_');
-
-  for (let i = 0; i < frags.length; i += 1) {
-    frags[i] = frags[i].charAt(0).toUpperCase() + frags[i].slice(1);
-
-    if (acronyms.includes(frags[i])) {
-      frags[i] = frags[i].toUpperCase();
-    }
-  }
-
-  return frags.join(' ');
-};
-
-/**
  * Parses urls to remove characters following the specified character
  */
-export const parseURL = (url: string, char: string): string => {
-  return url.split(char)[0];
+export const splitURLByChar = (
+  url: string,
+  char: string,
+  returnHalf: 'first' | 'second'
+): string => {
+  if (returnHalf === 'first') {
+    return url.split(char)[0];
+  }
+  return url.split(char)[1];
 };
 
 /**

--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -18,7 +18,7 @@ import {
   addUserSearchQuery,
   deleteUserSearchQuery,
   fetchUserCart,
-  fetchUserSearches,
+  fetchUserSearchQueries,
   updateUserCart,
 } from '../../api';
 import { CSSinJS } from '../../common/types';
@@ -95,7 +95,7 @@ const App: React.FC = () => {
           });
         });
 
-      void fetchUserSearches(accessToken as string)
+      void fetchUserSearchQueries(accessToken as string)
         .then((rawUserSearches) => {
           setUserSearchQueries(rawUserSearches.results);
         })

--- a/frontend/src/components/Cart/SearchesCard.tsx
+++ b/frontend/src/components/Cart/SearchesCard.tsx
@@ -8,7 +8,7 @@ import { Col, Typography } from 'antd';
 import React from 'react';
 import { useAsync } from 'react-async';
 import { useHistory } from 'react-router-dom';
-import { fetchResults, genUrlQuery } from '../../api';
+import { fetchSearchResults, generateSearchURLQuery } from '../../api';
 import { clickableRoute } from '../../api/routes';
 import { CSSinJS } from '../../common/types';
 import Card from '../DataDisplay/Card';
@@ -52,7 +52,7 @@ const SearchesCard: React.FC<Props> = ({
 
   // Generate the URL for receiving only the result count to reduce response time
 
-  const numResultsUrl = genUrlQuery(
+  const numResultsUrl = generateSearchURLQuery(
     project.facetsUrl,
     defaultFacets,
     activeFacets,
@@ -63,7 +63,7 @@ const SearchesCard: React.FC<Props> = ({
     }
   );
   const { data, isLoading, error } = useAsync({
-    promiseFn: fetchResults,
+    promiseFn: fetchSearchResults,
     reqUrl: numResultsUrl,
   });
 

--- a/frontend/src/components/Facets/FacetsForm.test.tsx
+++ b/frontend/src/components/Facets/FacetsForm.test.tsx
@@ -1,0 +1,15 @@
+import { humanizeFacetNames } from './FacetsForm';
+
+describe('Test humanizeStr', () => {
+  it('removes underscore and lowercases', () => {
+    expect(humanizeFacetNames('camel_case')).toEqual('Camel Case');
+  });
+
+  it('does not change properly formatted text ', () => {
+    expect(humanizeFacetNames('Proper Text')).toEqual('Proper Text');
+  });
+
+  it('converts acronyms to uppercase', () => {
+    expect(humanizeFacetNames('facet_id')).toEqual('Facet ID');
+  });
+});

--- a/frontend/src/components/Facets/FacetsForm.tsx
+++ b/frontend/src/components/Facets/FacetsForm.tsx
@@ -1,7 +1,6 @@
 import { Checkbox, Collapse, Form, Select } from 'antd';
 import React from 'react';
 import { CSSinJS } from '../../common/types';
-import { humanizeStr } from '../../common/utils';
 import { ActiveFacets, DefaultFacets, ParsedFacets } from './types';
 
 const styles: CSSinJS = {
@@ -18,6 +17,26 @@ export type Props = {
   activeFacets: ActiveFacets | Record<string, unknown>;
   projectFacets: ParsedFacets;
   onValuesChange: (allValues: { [key: string]: string[] | [] }) => void;
+};
+
+/**
+ * Converts facet names from snake_case to human readable.
+ *
+ * It also checks for acronyms to convert to uppercase.
+ */
+export const humanizeFacetNames = (str: string): string => {
+  const acronyms = ['Id', 'Cf', 'Cmor', 'Mip'];
+  const frags = str.split('_');
+
+  for (let i = 0; i < frags.length; i += 1) {
+    frags[i] = frags[i].charAt(0).toUpperCase() + frags[i].slice(1);
+
+    if (acronyms.includes(frags[i])) {
+      frags[i] = frags[i].toUpperCase();
+    }
+  }
+
+  return frags.join(' ');
 };
 
 const FacetsForm: React.FC<Props> = ({
@@ -69,7 +88,7 @@ const FacetsForm: React.FC<Props> = ({
                         const facetOptions = projectFacets[facet];
                         return (
                           <Collapse.Panel
-                            header={humanizeStr(facet)}
+                            header={humanizeFacetNames(facet)}
                             key={facet}
                             disabled={facetOptions.length === 0}
                           >

--- a/frontend/src/components/Search/Citation.tsx
+++ b/frontend/src/components/Search/Citation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PromiseFn, useAsync } from 'react-async';
-import { fetchCitation } from '../../api';
-import { parseURL } from '../../common/utils';
+import { fetchDatasetCitation } from '../../api';
+import { splitURLByChar } from '../../common/utils';
 import Alert from '../Feedback/Alert';
 import Skeleton from '../Feedback/Skeleton';
 import { RawCitation } from './types';
@@ -29,7 +29,7 @@ type CitationProps = {
 
 const Citation: React.FC<CitationProps> = ({ url }) => {
   const { data, error, isLoading } = useAsync({
-    promiseFn: (fetchCitation as unknown) as PromiseFn<RawCitation>,
+    promiseFn: (fetchDatasetCitation as unknown) as PromiseFn<RawCitation>,
     url,
   });
 
@@ -37,7 +37,7 @@ const Citation: React.FC<CitationProps> = ({ url }) => {
     <div>
       <div>
         <a
-          href={parseURL(url, '.json')}
+          href={splitURLByChar(url, '.json', 'first')}
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/frontend/src/components/Search/FilesTable.tsx
+++ b/frontend/src/components/Search/FilesTable.tsx
@@ -2,8 +2,8 @@ import { DownloadOutlined } from '@ant-design/icons';
 import { Form, Select, Table as TableD } from 'antd';
 import React from 'react';
 import { PromiseFn, useAsync } from 'react-async';
-import { fetchFiles, openDownloadURL } from '../../api';
-import { formatBytes, parseURL } from '../../common/utils';
+import { fetchDatasetFiles, openDownloadURL } from '../../api';
+import { formatBytes, splitURLByChar } from '../../common/utils';
 import Alert from '../Feedback/Alert';
 import Button from '../General/Button';
 import { RawSearchResults } from './types';
@@ -20,7 +20,7 @@ export const genDownloadUrls = (urls: string[]): DownloadUrls => {
   const newUrls: DownloadUrls = [];
   urls.forEach((url) => {
     const downloadType = url.split('|').pop();
-    let downloadUrl = parseURL(url, '|');
+    let downloadUrl = splitURLByChar(url, '|', 'first');
 
     if (downloadType === 'OPeNDAP') {
       downloadUrl = downloadUrl.replace('.html', '.dods');
@@ -39,7 +39,7 @@ const FilesTable: React.FC<Props> = ({ id }) => {
 
   const { data, error, isLoading } = useAsync({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    promiseFn: (fetchFiles as unknown) as PromiseFn<Record<string, any>>,
+    promiseFn: (fetchDatasetFiles as unknown) as PromiseFn<Record<string, any>>,
     id,
   });
 

--- a/frontend/src/components/Search/Table.tsx
+++ b/frontend/src/components/Search/Table.tsx
@@ -19,7 +19,7 @@ import { SizeType } from 'antd/lib/config-provider/SizeContext';
 import { TablePaginationConfig } from 'antd/lib/table';
 import React from 'react';
 import { fetchWgetScript, openDownloadURL } from '../../api';
-import { formatBytes, objectHasKey, parseURL } from '../../common/utils';
+import { formatBytes, objectHasKey, splitURLByChar } from '../../common/utils';
 import { UserCart } from '../Cart/types';
 import Button from '../General/Button';
 import Divider from '../General/Divider';
@@ -268,7 +268,7 @@ const Table: React.FC<Props> = ({
               <Button
                 type="link"
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                href={parseURL(record.xlink![1], '|')}
+                href={splitURLByChar(record.xlink![1], '|', 'first')}
                 target="_blank"
               >
                 PID

--- a/frontend/src/components/Search/index.tsx
+++ b/frontend/src/components/Search/index.tsx
@@ -7,7 +7,7 @@ import { Col, Row, Typography } from 'antd';
 import humps from 'humps';
 import React from 'react';
 import { DeferFn, useAsync } from 'react-async';
-import { fetchResults, genUrlQuery } from '../../api';
+import { fetchSearchResults, generateSearchURLQuery } from '../../api';
 import { clickableRoute } from '../../api/routes';
 import { CSSinJS } from '../../common/types';
 import { objectIsEmpty } from '../../common/utils';
@@ -131,7 +131,7 @@ const Search: React.FC<Props> = ({
 }) => {
   const { data: results, error, isLoading, run } = useAsync({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    deferFn: (fetchResults as unknown) as DeferFn<Record<string, any>>,
+    deferFn: (fetchSearchResults as unknown) as DeferFn<Record<string, any>>,
   });
 
   const [filtersExist, setFiltersExist] = React.useState<boolean>(false);
@@ -155,7 +155,7 @@ const Search: React.FC<Props> = ({
   // Generate the current request URL based on filters
   React.useEffect(() => {
     if (!objectIsEmpty(activeProject)) {
-      const reqUrl = genUrlQuery(
+      const reqUrl = generateSearchURLQuery(
         (activeProject as RawProject).facetsUrl,
         defaultFacets,
         activeFacets,


### PR DESCRIPTION

## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR fixes the URL generated for fetching files for a specific dataset.
It also includes:
- Update function names for API calls
- Move and rename humanizeStr to FacetsForm as humanizeFacetNames
- Update parseURL to splitURLByChar with option to return either first or second half

Fixes # (issue)
https://acme-climate.atlassian.net/browse/MG-504

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
