### PR TITLE
Update directory to fix proxy dependencies

### DIFF
--- a/frontend/docker/local/proxy/Dockerfile
+++ b/frontend/docker/local/proxy/Dockerfile
@@ -2,10 +2,10 @@
 FROM node:13.14.0-alpine
 
 # Set working directory
-WORKDIR /app
+WORKDIR /proxy
 
 # Add `/app/node_modules/.bin` to $PATH
-ENV PATH /app/node_modules/.bin:$PATH
+ENV PATH /proxy/node_modules/.bin:$PATH
 
 # Install proxy dependencies
 COPY package.json ./
@@ -14,7 +14,7 @@ RUN yarn add dotenv@^8.2.0
 RUN yarn add cors-anywhere
 
 # Add proxy
-COPY . ./
+COPY src/env.ts ./
 COPY proxy.js ./
 
 # Start proxy


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR fixes the missing `dotenv` dependency for the `proxy` docker-compose service. The issue was that the `proxy` service's dependencies were being overwritten by the `react` service since they were sharing the `/app` working directory. The fix is updating the `proxy` service's working directory from `/app` to `/proxy`

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
