### PR TITLE
Fix eslint and prettier commands in package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "test": "CI=1 env-cmd -f .envs/.local/.react react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:watch": "env-cmd -f .envs/.local/.react react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:coverage": "CI=1 env-cmd -f .envs/.local/.react react-scripts test --coverage --env=jest-environment-jsdom-sixteen",
-    "lint": "eslint src/**/*.{js,jsx,ts,tsx} --no-error-on-unmatched-pattern",
+    "lint": "eslint './src/**/*.{js,jsx,ts,tsx,json}' --fix --no-error-on-unmatched-pattern",
     "precommit": "lint-staged"
   },
   "eslintConfig": {
@@ -97,10 +97,10 @@
   },
   "lint-staged": {
     "src/**/*.+(js|jsx|ts|tsx|json)": [
-      "eslint --fix --no-error-on-unmatched-pattern"
+      "eslint './src/**/*.{js,jsx,ts,tsx,json}' --fix --no-error-on-unmatched-pattern"
     ],
     "src/**/*.+(js|jsx|ts|tsx|css|sass|less|json)": [
-      "prettier --write"
+      "prettier --write './src/**/*.{js,jsx,ts,tsx,css,sass,less,json}'"
     ]
   }
 }


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

The pre-commit hook would fail at the ESLint stage, which sometimes causes changes to be discarded and/or without any errors in the log.

The root cause was related to missing quotation marks for the glob pattern matching in the ESLint commands of `package.json`. It would not run ESLint correctly and ignore linting errors.

Fixes # (issue)
https://acme-climate.atlassian.net/browse/MG-508?atlOrigin=eyJpIjoiN2M1MDhlYzkxNTY4NGYwOWFiMDc1ODU1Mjc3NzdhYzQiLCJwIjoiaiJ9

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
