### PR TITLE
Remove lint-staged and update .pre-commit.config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         name: eslint
         language: system
         files: .+(js|jsx|ts|tsx|css|sass|less|json)
-        entry: yarn --cwd frontend precommit
+        entry: bash -c 'cd frontend && yarn lint'
 
   # BACKEND
   # ------------------------------------------------------------------------------

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "env-cmd": "10.1.0",
     "humps": "2.0.1",
     "keycloak-js": "11.0.2",
-    "lint-staged": "10.4.0",
     "query-string": "6.13.4",
     "react": "16.13.1",
     "react-async": "10.0.1",
@@ -94,13 +93,5 @@
         "lines": 100
       }
     }
-  },
-  "lint-staged": {
-    "src/**/*.+(js|jsx|ts|tsx|json)": [
-      "eslint './src/**/*.{js,jsx,ts,tsx,json}' --fix --no-error-on-unmatched-pattern"
-    ],
-    "src/**/*.+(js|jsx|ts|tsx|css|sass|less|json)": [
-      "prettier --write './src/**/*.{js,jsx,ts,tsx,css,sass,less,json}'"
-    ]
   }
 }


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR removes the `lint-staged` package and updates the `.pre-commit.config.yaml` to run ESLint + prettier directly with `yarn lint`. This update was necessary in order to fix an issue where lint-staged would fail even though no linting issues were found. It also makes the pre-commit check consistent with the GitHub Actions front-end build.

Fixes # (issue)
https://acme-climate.atlassian.net/browse/MG-508?atlOrigin=eyJpIjoiN2M1MDhlYzkxNTY4NGYwOWFiMDc1ODU1Mjc3NzdhYzQiLCJwIjoiaiJ9

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
