### PR TITLE
Add user support button and modal

### DIFF
--- a/frontend/src/components/App/App.test.tsx
+++ b/frontend/src/components/App/App.test.tsx
@@ -1015,3 +1015,28 @@ describe('User search library', () => {
     });
   });
 });
+
+describe('User support', () => {
+  it('renders user support modal when clicking fixed button and is closeable', () => {
+    const { getByRole } = customRender(
+      <Router>
+        <App />
+      </Router>
+    );
+
+    // support button renders
+    const supportBtn = getByRole('img', { name: 'question', hidden: true });
+    expect(supportBtn).toBeTruthy();
+
+    // click support button
+    fireEvent.click(supportBtn);
+
+    // GitHub icon renders
+    const githubIcon = getByRole('img', { name: 'github', hidden: true });
+    expect(githubIcon).toBeTruthy();
+
+    // click close button
+    const closeBtn = getByRole('button', { name: 'Close' });
+    fireEvent.click(closeBtn);
+  });
+});

--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -3,9 +3,10 @@ import {
   BookOutlined,
   DeleteOutlined,
   HomeOutlined,
+  QuestionOutlined,
   ShoppingCartOutlined,
 } from '@ant-design/icons';
-import { Breadcrumb, Layout, message } from 'antd';
+import { Affix, Breadcrumb, Button, Layout, message } from 'antd';
 import React from 'react';
 import {
   BrowserRouter as Router,
@@ -38,6 +39,7 @@ import {
 import NavBar from '../NavBar';
 import Search from '../Search';
 import { RawSearchResults, TextInputs } from '../Search/types';
+import Support from '../Support';
 import './App.css';
 
 const styles: CSSinJS = {
@@ -58,6 +60,10 @@ const App: React.FC = () => {
   const authState = React.useContext(AuthContext);
   const { access_token: accessToken, pk } = authState;
   const isAuthenticated = accessToken && pk;
+
+  const [supportModalVisible, setSupportModalVisible] = React.useState<boolean>(
+    false
+  );
 
   const [activeProject, setActiveProject] = React.useState<
     RawProject | Record<string, unknown>
@@ -400,6 +406,19 @@ const App: React.FC = () => {
             </Switch>
           </Layout.Content>
         </Layout>
+        <Affix style={{ position: 'fixed', bottom: 20, right: 20 }}>
+          <Button
+            type="primary"
+            shape="circle"
+            size="large"
+            icon={<QuestionOutlined style={{ fontSize: '24px' }} />}
+            onClick={() => setSupportModalVisible(true)}
+          ></Button>
+        </Affix>
+        <Support
+          visible={supportModalVisible}
+          onClose={() => setSupportModalVisible(false)}
+        />
       </div>
     </Router>
   );

--- a/frontend/src/components/Feedback/Modal.tsx
+++ b/frontend/src/components/Feedback/Modal.tsx
@@ -1,0 +1,32 @@
+import { Modal as ModalD } from 'antd';
+import React from 'react';
+
+type Props = {
+  visible: boolean;
+  title?: React.ReactNode;
+  onClose?: () => void;
+  centered?: boolean;
+  children: React.ReactNode;
+};
+
+const Modal: React.FC<Props> = ({
+  visible,
+  title,
+  onClose,
+  centered,
+  children,
+}) => {
+  return (
+    <ModalD
+      visible={visible}
+      title={title}
+      onOk={onClose}
+      onCancel={onClose}
+      centered={centered}
+    >
+      {children}
+    </ModalD>
+  );
+};
+
+export default Modal;

--- a/frontend/src/components/General/Button.tsx
+++ b/frontend/src/components/General/Button.tsx
@@ -22,6 +22,8 @@ type Props = {
   danger?: boolean;
   children?: React.ReactElement | React.ReactNode | string;
   loading?: boolean;
+  shape?: 'circle' | 'round';
+  size?: 'large' | 'middle' | 'small';
 };
 
 const Button: React.FC<Props> = ({
@@ -36,6 +38,8 @@ const Button: React.FC<Props> = ({
   danger = false,
   loading = false,
   children,
+  shape,
+  size,
 }) => {
   return (
     <ButtonD
@@ -49,6 +53,8 @@ const Button: React.FC<Props> = ({
       disabled={disabled}
       danger={danger}
       loading={loading}
+      shape={shape}
+      size={size}
     >
       {children}
     </ButtonD>

--- a/frontend/src/components/Support/index.tsx
+++ b/frontend/src/components/Support/index.tsx
@@ -1,0 +1,53 @@
+import { GithubOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import React from 'react';
+import Modal from '../Feedback/Modal';
+
+export type Props = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+const Support: React.FC<Props> = ({ visible, onClose }) => {
+  return (
+    <div>
+      <Modal
+        visible={visible}
+        title={
+          <div>
+            <h2>
+              <QuestionCircleOutlined /> MetaGrid Support
+            </h2>
+            <p style={{ fontSize: '14px' }}>
+              Checkback for documentation and FAQs in the near future. A user
+              support ticket form will also be integrated!
+            </p>
+          </div>
+        }
+        onClose={onClose}
+        centered
+      >
+        <p>
+          Questions, suggestions, or problems? Please visit our GitHub page to
+          open an issue.
+        </p>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            margin: '12px',
+          }}
+        >
+          <a
+            href="https://github.com/aims-group/metagrid/issues"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <GithubOutlined style={{ fontSize: '32px' }} /> GitHub Issues
+          </a>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default Support;


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR adds a fixed user support button in the corner of the application which toggles a modal. The modal contains information on how the user can submit questions, comments, etc. using GitHub issues. It also let's the user know that documentation, FAQs, and a user ticket system is on the way.

![Screen Shot 2020-10-05 at 4 44 43 PM](https://user-images.githubusercontent.com/25624127/95143140-28d4fd00-072a-11eb-8565-bed72bb2e5e3.png)

![Screen Shot 2020-10-05 at 4 45 55 PM](https://user-images.githubusercontent.com/25624127/95143200-4c984300-072a-11eb-9c11-f764ac38c462.png)

Fixes # (issue)
https://acme-climate.atlassian.net/browse/MG-514?atlOrigin=eyJpIjoiOTFhMGJhZGY4ZjA4NGE3Y2IwODU3YjI4YWFlYTRiNTMiLCJwIjoiaiJ9

Summary of Changes
- Add Affix component with Button to toggle Support component
- Add properties to Button component
- Add Modal component
- Add tests to cover updates

## Type of change

<!--
  Please delete options that are not relevant.
-->

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
