### PR TITLE
Fix Lets Encrypt cert and serving static files for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,10 @@ You will need to configure the domains used in Traefik's rules to match what you
 
 1. Enter directory: `./backend/docker/production/traefik/`
 2. Open `traefik.yml` in your editor
-3. Edit lines using example.com domains
-
-- For example, esgf-dev1.llnl.gov or esgf-dev1.llnl.gov/metagrid-backend.
+3. Edit both `` rule: "Host(`example.com`) && PathPrefix(`/prefix`)" ``
+   - Change `example.com` to the domain name (e.g. `esgf-dev1.llnl.gov`)
+   - Change `/prefix` to the domain subdirectory (e.g. `/metagrid-backend`)
+     - If you don't use a subdirectory, delete both `` PathPrefix(`prefix`) ``
 
 Once configured, Traefik will get you a valid certificate from Lets Encrypt and update it automatically.
 

--- a/backend/docker/production/traefik/traefik.yml
+++ b/backend/docker/production/traefik/traefik.yml
@@ -23,7 +23,7 @@ certificatesResolvers:
 http:
   routers:
     web-router:
-      rule: "Host(`example.com`) || Host(`www.example.com`)"
+      rule: "Host(`example.com`) && PathPrefix(`/prefix`)"
 
       entryPoints:
         - web
@@ -33,7 +33,7 @@ http:
       service: django
 
     web-secure-router:
-      rule: "Host(`example.com`) || Host(`www.example.com`)"
+      rule: "Host(`example.com`) || PathPrefix(`/prefix`)"
 
       entryPoints:
         - web-secure

--- a/backend/metagrid/config/base.py
+++ b/backend/metagrid/config/base.py
@@ -111,6 +111,8 @@ DATABASES["default"]["ATOMIC_REQUESTS"] = True
 STATIC_ROOT = str(ROOT_DIR("staticfiles"))
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 STATIC_URL = "/static/"
+if DOMAIN_SUBDIRECTORY:
+    STATIC_URL = f"{DOMAIN_SUBDIRECTORY}{STATIC_URL}"
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = []  # type: List[str]
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#staticfiles-finders
@@ -119,12 +121,15 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
+
 # MEDIA
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-root
 MEDIA_ROOT = str(ROOT_DIR)
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = "/media/"
+if DOMAIN_SUBDIRECTORY:
+    MEDIA_URL = f"{DOMAIN_SUBDIRECTORY}{MEDIA_URL}"
 
 # TEMPLATES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR fixes two issues:

1. Static files not being served over HTTPS to the client.
  - Issue: Including a subdirectory for the Django site caused failure to match the `STATIC_URL` setting
  - Fix: Prepend `DOMAIN_SUBDIRECTORY` to `STATIC_URL`

2. Lets Encrypt not issuing certificate validation for the domain
 - Issue: Lets Encrypt outputs an error related to an invalid character in the hostname being issued certification. This is because `Host` does not support the / character for a subdirectory.
 - Fix: Update the `rule` to use `PathPrefix` in `traefik.yml`

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [ ] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [ ] CI/CD Build

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
