### PR TITLE
Disable DRF browsable API in prod

### DIFF
--- a/backend/metagrid/config/base.py
+++ b/backend/metagrid/config/base.py
@@ -121,7 +121,6 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 
-
 # MEDIA
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-root
@@ -234,14 +233,12 @@ LOGGING = {
 
 # django-rest-framework - https://www.django-rest-framework.org/api-guide/settings/
 # -------------------------------------------------------------------------------
+DEFAULT_RENDERER_CLASSES = ["rest_framework.renderers.JSONRenderer"]
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": int(env("DJANGO_PAGINATION_LIMIT", default=10)),
     "DATETIME_FORMAT": "%Y-%m-%dT%H:%M:%S%z",
-    "DEFAULT_RENDERER_CLASSES": (
-        "rest_framework.renderers.JSONRenderer",
-        "rest_framework.renderers.BrowsableAPIRenderer",
-    ),
+    "DEFAULT_RENDERER_CLASSES": DEFAULT_RENDERER_CLASSES,
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated"
     ],

--- a/backend/metagrid/config/local.py
+++ b/backend/metagrid/config/local.py
@@ -22,6 +22,16 @@ EMAIL_BACKEND = env(
     default="django.core.mail.backends.console.EmailBackend",
 )
 
+# django-rest-framework - https://www.django-rest-framework.org/api-guide/settings/
+
+# -------------------------------------------------------------------------------
+DEFAULT_RENDERER_CLASSES.append(  # noqa F405
+    "rest_framework.renderers.BrowsableAPIRenderer",
+)
+REST_FRAMEWORK[  # noqa F405
+    "DEFAULT_RENDERER_CLASSES"
+] = DEFAULT_RENDERER_CLASSES  # noqa F405
+
 # WhiteNoise
 # ------------------------------------------------------------------------------
 # http://whitenoise.evans.io/en/latest/django.html#using-whitenoise-in-development


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR disables the Django REST Framework browsable API in production. 

Also note, there was an issue serving the `rest_framework` package static files even though the `collectstatic` command was putting the files in the correct `/app/staticfiles` directory. This is now a non-issue by disabling the page entirely.

Fixes # (issue)

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [ ] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [ ] CI/CD Build

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
