### PR TITLE
Fix URL for fetching a dataset's files 

### DIFF
--- a/frontend/src/api/index.test.ts
+++ b/frontend/src/api/index.test.ts
@@ -77,7 +77,7 @@ describe('test genUrlQuery()', () => {
     );
 
     expect(url).toEqual(
-      `${apiRoutes.esgfDatasets}?limit=10&offset=0&latest=true&replica=false&query=input1,input2&facet1=var1,var2&facet2=var3,var4`
+      `${apiRoutes.esgfSearch}?limit=10&offset=0&latest=true&replica=false&query=input1,input2&facet1=var1,var2&facet2=var3,var4`
     );
   });
   it('returns formatted url with offset of 200 and limit of 100 on page 3', () => {
@@ -94,7 +94,7 @@ describe('test genUrlQuery()', () => {
       pagination
     );
     expect(url).toEqual(
-      `${apiRoutes.esgfDatasets}?limit=100&offset=200&latest=true&replica=false&query=input1,input2&facet1=var1,var2&facet2=var3,var4`
+      `${apiRoutes.esgfSearch}?limit=100&offset=200&latest=true&replica=false&query=input1,input2&facet1=var1,var2&facet2=var3,var4`
     );
   });
   it('returns formatted url without free-text', () => {
@@ -111,7 +111,7 @@ describe('test genUrlQuery()', () => {
       pagination
     );
     expect(url).toEqual(
-      `${apiRoutes.esgfDatasets}?limit=10&offset=0&latest=true&replica=false&query=*&facet1=var1,var2&facet2=var3,var4`
+      `${apiRoutes.esgfSearch}?limit=10&offset=0&latest=true&replica=false&query=*&facet1=var1,var2&facet2=var3,var4`
     );
   });
 
@@ -129,16 +129,16 @@ describe('test genUrlQuery()', () => {
       pagination
     );
     expect(url).toEqual(
-      `${apiRoutes.esgfDatasets}?limit=10&offset=0&latest=true&replica=false&query=input1,input2&`
+      `${apiRoutes.esgfSearch}?limit=10&offset=0&latest=true&replica=false&query=input1,input2&`
     );
   });
 });
 
-describe('test fetchResults()', () => {
+describe('test fetchSearchResults()', () => {
   let reqUrl: string;
 
   beforeEach(() => {
-    reqUrl = apiRoutes.esgfDatasets;
+    reqUrl = apiRoutes.esgfSearch;
   });
   it('returns results', async () => {
     reqUrl += '?query=input1,input2&facet1=var1,var2&facet2=var3,var4';
@@ -155,7 +155,7 @@ describe('test fetchResults()', () => {
   });
   it('catches and throws an error', async () => {
     server.use(
-      rest.get(apiRoutes.esgfDatasets, (_req, res, ctx) => {
+      rest.get(apiRoutes.esgfSearch, (_req, res, ctx) => {
         return res(ctx.status(404));
       })
     );
@@ -226,7 +226,7 @@ describe('test fetchFiles()', () => {
   });
   it('catches and throws an error', async () => {
     server.use(
-      rest.get(apiRoutes.esgfFiles, (_req, res, ctx) => {
+      rest.get(apiRoutes.esgfSearch, (_req, res, ctx) => {
         return res(ctx.status(404));
       })
     );

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -3,7 +3,6 @@
  */
 import humps from 'humps';
 import queryString from 'query-string';
-import { splitURLByChar } from '../common/utils';
 import {
   RawUserCart,
   RawUserSearchQuery,
@@ -257,7 +256,7 @@ export const generateSearchURLQuery = (
     .replace('limit=0', `limit=${pagination.pageSize}`)
     .replace('offset=0', `offset=${offset}`);
 
-  const url = `${apiRoutes.esgfDatasets}?${newBaseUrl}&${defaultFacetsStr}&${stringifyText}&${activeFacetsStr}`;
+  const url = `${apiRoutes.esgfSearch}?${newBaseUrl}&${defaultFacetsStr}&${stringifyText}&${activeFacetsStr}`;
   return url;
 };
 
@@ -342,12 +341,10 @@ export const fetchDatasetFiles = async ({
   id: string;
 }): // eslint-disable-next-line @typescript-eslint/no-explicit-any
 Promise<{ [key: string]: any }> => {
-  // The dataset's source node is contained in its id, so strip the URL suffix.
-  const sourceNodeURL = splitURLByChar(id, '|', 'second');
-
-  const url = `${apiRoutes.esgfFiles
-    .replace(':datasetID', id)
-    .replace(':sourceNode', sourceNodeURL)}`;
+  const url = queryString.stringifyUrl({
+    url: apiRoutes.esgfSearch,
+    query: { format: 'application/solr+json', type: 'File', dataset_id: id },
+  });
 
   return axios
     .get(url)

--- a/frontend/src/api/mock/server-handlers.ts
+++ b/frontend/src/api/mock/server-handlers.ts
@@ -45,10 +45,7 @@ const handlers = [
   rest.get(apiRoutes.projects, (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json({ results: projectsFixture() }));
   }),
-  rest.get(apiRoutes.esgfDatasets, (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(ESGFSearchAPIFixture()));
-  }),
-  rest.get(apiRoutes.esgfFiles, (_req, res, ctx) => {
+  rest.get(apiRoutes.esgfSearch, (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json(ESGFSearchAPIFixture()));
   }),
   rest.get(apiRoutes.citation, (_req, res, ctx) => {

--- a/frontend/src/api/routes.ts
+++ b/frontend/src/api/routes.ts
@@ -17,8 +17,7 @@ type ApiRoutes = {
   userSearches: string;
   userSearch: string;
   projects: string;
-  esgfDatasets: string;
-  esgfFiles: string;
+  esgfSearch: string;
   citation: string;
   wget: string;
 };
@@ -41,10 +40,8 @@ const apiRoutes: ApiRoutes = {
   userSearches: `${metagridApiURL}/api/v1/carts/searches/`,
   userSearch: `${metagridApiURL}/api/v1/carts/searches/:pk/`,
   projects: `${metagridApiURL}/api/v1/projects/`,
-  // ESGF Search API - datasets
-  esgfDatasets: `${proxyURL}/${esgfNodeURL}/esg-search/search/`,
-  // ESGF Search API - files
-  esgfFiles: `${proxyURL}/${esgfNodeURL}/search_files/:datasetID/:sourceNode/`,
+  // ESGF Search API
+  esgfSearch: `${proxyURL}/${esgfNodeURL}/esg-search/search/`,
   // ESGF Citation API (uses dummy link)
   citation: `${proxyURL}/citation_url`,
   // ESGF wget API

--- a/frontend/src/common/utils.test.ts
+++ b/frontend/src/common/utils.test.ts
@@ -3,6 +3,7 @@ import {
   objectHasKey,
   objectIsEmpty,
   shallowCompareObjects,
+  splitURLByChar,
 } from './utils';
 
 describe('Test objectIsEmpty', () => {
@@ -29,6 +30,18 @@ describe('Test objectHasKey', () => {
   });
 });
 
+describe('Test splitURLbyChar', () => {
+  let url: string;
+  beforeEach(() => {
+    url = 'first.com|second.com';
+  });
+  it('returns first half of the split', () => {
+    expect(splitURLByChar(url, '|', 'first')).toEqual('first.com');
+  });
+  it('returns second half of the split', () => {
+    expect(splitURLByChar(url, '|', 'second')).toEqual('second.com');
+  });
+});
 describe('Test formatBytes', () => {
   it('returns the correct rounded format', () => {
     expect(formatBytes(0)).toEqual('0 Bytes');

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -45,6 +45,7 @@ export const shallowCompareObjects = (
   Object.keys(obj1).every(
     (key) => obj2.hasOwnProperty.call(obj2, key) && obj1[key] === obj2[key]
   );
+
 /**
  * Converts binary bytes into another size
  * https://stackoverflow.com/a/18650828

--- a/frontend/src/components/Cart/SearchesCard.test.tsx
+++ b/frontend/src/components/Cart/SearchesCard.test.tsx
@@ -47,7 +47,7 @@ it('renders component and handles button clicks', async () => {
 
 it('displays alert error when api fails to return response', async () => {
   server.use(
-    rest.get(apiRoutes.esgfDatasets, (_req, res, ctx) => {
+    rest.get(apiRoutes.esgfSearch, (_req, res, ctx) => {
       return res(ctx.status(404));
     })
   );

--- a/frontend/src/components/Search/FilesTable.test.tsx
+++ b/frontend/src/components/Search/FilesTable.test.tsx
@@ -38,7 +38,7 @@ const defaultProps: Props = {
 describe('test FilesTable component', () => {
   it('returns Alert when there is an error fetching files', async () => {
     server.use(
-      rest.get(apiRoutes.esgfFiles, (_req, res, ctx) => {
+      rest.get(apiRoutes.esgfSearch, (_req, res, ctx) => {
         return res(ctx.status(404));
       })
     );

--- a/frontend/src/components/Search/index.test.tsx
+++ b/frontend/src/components/Search/index.test.tsx
@@ -133,7 +133,7 @@ describe('test Search component', () => {
     };
 
     server.use(
-      rest.get(apiRoutes.esgfDatasets, (_req, res, ctx) => {
+      rest.get(apiRoutes.esgfSearch, (_req, res, ctx) => {
         return res(ctx.status(200), ctx.json(response));
       })
     );


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR fixes the URL used to fetch the files for a dataset. 

Previously, the request was sent to the CoG API endpoint (Search API wrapper, soon to be deprecated with CoG) with the wrong node parameter, which also caused errors fetching files. Now it uses the Search API directly with the correct parameters.

Fixes # (issue)
https://acme-climate.atlassian.net/browse/MG-556?atlOrigin=eyJpIjoiYWZjMzhiZjUwZTA3NDE4M2ExNmIxNDY1NWI3ZDhmZDUiLCJwIjoiaiJ9

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
