### PR TITLE
Add label and tooltip for optional facets

### DIFF
--- a/frontend/src/api/mock/fixtures.ts
+++ b/frontend/src/api/mock/fixtures.ts
@@ -33,7 +33,11 @@ export const rawProjectFixture = (
   const defaults: RawProject = {
     pk: '1',
     name: 'test1',
-    facetsByGroup: { group1: ['data_node'], group2: ['facet2'] },
+    facetsByGroup: {
+      group1: ['data_node'],
+      group2: ['facet2'],
+      group3: ['optional'],
+    },
     facetsUrl: 'https://esgf-node.llnl.gov/esg-search/search/?offset=0&limit=0',
     fullName: 'test1',
   };
@@ -83,6 +87,7 @@ export const rawFacetsFixture = (props: Partial<RawFacets> = {}): RawFacets => {
   const defaults: RawFacets = {
     data_node: ['aims3.llnl.gov', 3, 'esgf1.dkrz.de', 5],
     facet2: ['baz', 2, 'fubar', 3],
+    optional: ['none', 8],
   };
   return { ...defaults, ...props } as RawFacets;
 };
@@ -99,6 +104,7 @@ export const parsedFacetsFixture = (
       ['baz', 2],
       ['fubar', 3],
     ],
+    optional: [['none', 8]],
   };
   return { ...defaults, ...props } as ParsedFacets;
 };

--- a/frontend/src/components/Facets/FacetsForm.tsx
+++ b/frontend/src/components/Facets/FacetsForm.tsx
@@ -1,3 +1,4 @@
+import { InfoCircleOutlined } from '@ant-design/icons';
 import { Checkbox, Collapse, Form, Select } from 'antd';
 import React from 'react';
 import { CSSinJS } from '../../common/types';
@@ -90,17 +91,30 @@ const FacetsForm: React.FC<Props> = ({
                     {Object.keys(projectFacets).map((facet) => {
                       if (facetsByGroup[group].includes(facet)) {
                         const facetOptions = projectFacets[facet];
-
+                        const isOptionalforDatasets = facetOptions[0].includes(
+                          'none'
+                        );
                         return (
                           <Collapse.Panel
                             header={humanizeFacetNames(facet)}
                             key={facet}
-                            disabled={facetOptions.length === 0}
                           >
                             <Form.Item
                               style={{ marginBottom: '4px' }}
                               key={facet}
                               name={facet}
+                              label={
+                                isOptionalforDatasets ? '(Optional)' : undefined
+                              }
+                              tooltip={
+                                isOptionalforDatasets
+                                  ? {
+                                      title:
+                                        'Selecting the "none" option filters for datasets that do not use this facet.',
+                                      icon: <InfoCircleOutlined />,
+                                    }
+                                  : undefined
+                              }
                             >
                               <Select
                                 data-testid={`${facet}-form-select`}

--- a/frontend/src/components/Facets/index.tsx
+++ b/frontend/src/components/Facets/index.tsx
@@ -62,6 +62,7 @@ const Facets: React.FC<Props> = ({
     // Have to check if selected default facets is not undefined, otherwise a
     // test fails because ant design's form's initialValues does not work after
     // the initial detection of value changes.
+    /* istanbul ignore else */
     if (selectedDefaults) {
       selectedDefaults.forEach((facet) => {
         newDefaults[facet] = true;


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR adds a label and tooltip for optional facets, which are facets that have an option called `none`.

Fixes # (issue)
https://acme-climate.atlassian.net/browse/MG-565?atlOrigin=eyJpIjoiNTkxOTc0OTg2ZmU2NDcyNDkwMjFjNjE4YzU0MjY1MGEiLCJwIjoiaiJ9

## Type of change

<!--
  Please delete options that are not relevant.
-->

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
