### PR TITLE
Fix warnings for non-unique keys

### DIFF
--- a/frontend/src/components/NavBar/LeftMenu.tsx
+++ b/frontend/src/components/NavBar/LeftMenu.tsx
@@ -37,7 +37,7 @@ const LeftMenu: React.FC<Props> = ({
     }
 
     const selectedProj: RawProject | undefined = projects.find(
-      (obj) => obj.name === values.project
+      (obj) => obj.name === values.projectTextInput
     );
 
     /* istanbul ignore else */
@@ -55,14 +55,14 @@ const LeftMenu: React.FC<Props> = ({
   return (
     <div data-testid="left-menu">
       <Form
-        initialValues={{ project: projects[0].name }}
+        initialValues={{ projectTextInput: projects[0].name }}
         style={styles.searchForm}
         form={form}
         onFinish={onFinish}
       >
         <Input.Group compact>
           <Form.Item
-            name="project"
+            name="projectTextInput"
             rules={[{ required: true, message: 'Project is required' }]}
             style={{ width: '15%' }}
           >

--- a/frontend/src/components/Search/Table.tsx
+++ b/frontend/src/components/Search/Table.tsx
@@ -195,8 +195,11 @@ const Table: React.FC<Props> = ({
       width: 200,
       render: (record: RawSearchResult) => {
         const availableDownloads = ['wget'];
-        let globusCompatible = false;
+        const { id } = record;
+        // Unique key for the download form item
+        const formKey = `download-${id}`;
 
+        let globusCompatible = false;
         record.access.forEach((download) => {
           if (download === 'Globus') {
             globusCompatible = true;
@@ -239,10 +242,12 @@ const Table: React.FC<Props> = ({
             </p>
             <Form
               layout="inline"
-              onFinish={({ download }) => handleDownloadForm(download)}
-              initialValues={{ download: availableDownloads[0] }}
+              onFinish={({ [formKey]: download }) =>
+                handleDownloadForm(download)
+              }
+              initialValues={{ [formKey]: availableDownloads[0] }}
             >
-              <Form.Item name="download">
+              <Form.Item name={formKey}>
                 <Select style={{ width: 120 }}>
                   {availableDownloads.map((option) => (
                     <Select.Option key={option} value={option}>


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR fixes non-unique key warnings. 
Warnings:
1. There are two Project select forms using `name=project`. 
Fix: Set `name=projectTextInput` for the LeftMenu component's Project select form.
2. The download forms in the table used the same `name=download`. 
Fix: Create a unique name by appending the dataset's id to download.

Fixes # (issue)
https://acme-climate.atlassian.net/browse/MG-559?atlOrigin=eyJpIjoiOWI4Mzk4ZTFmY2JhNGVmMTk1MTczMGZmNjUyZTNlMDIiLCJwIjoiaiJ9

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [ ] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [ ] CI/CD Build

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
