### PR TITLE
Fix Search API query string for input4MIPs

### DIFF
--- a/backend/metagrid/projects/models.py
+++ b/backend/metagrid/projects/models.py
@@ -52,28 +52,25 @@ class Project(models.Model):
             "limit": 0,
             "type": "Dataset",
             "format": "application/solr+json",
-            "project": self.project_url_param,
             "facets": ", ".join(facets),
         }  # type: Dict[str, Union[int, str, List[str]]]
-
+        params = {**self.project_param, **params}
         query_string = urllib.parse.urlencode(params, True)
-
-        if self.name == "All (except CMIP6)":
-            query_string = query_string.replace(
-                "project=CMIP6", "project!=CMIP6"
-            )
 
         return query_string
 
     @property
-    def project_url_param(self) -> str:
-        if self.name == "E3SM":
-            return self.name.lower()
-        elif self.name == "All (except CMIP6)":
-            # NOT operator will be performed CMIP6
-            return "CMIP6"
+    def project_param(self) -> Dict[str, str]:
+        """Generates the respective url param based on the project.
 
-        return self.name
+        For example, input4MIPs uses 'activity_id' instead of 'project'
+        """
+        project_params = {
+            "E3SM": {"project": self.name.lower()},
+            "All (except CMIP6)": {"project!": "CMIP6"},
+            "input4MIPs": {"activity_id": self.name},
+        }
+        return project_params.get(self.name, {"project": self.name})
 
 
 class Facet(models.Model):

--- a/backend/metagrid/projects/tests/test_models.py
+++ b/backend/metagrid/projects/tests/test_models.py
@@ -52,10 +52,16 @@ class TestProjectModel:
             name="All (except CMIP6)"
         )  # type: Project
 
-        assert "project!=CMIP6" in cross_project.facets_url
+        # The HTML URL encoding for ! (NOT) is %21
+        assert "project%21=CMIP6" in cross_project.facets_url
 
-    def test_project_url_param_success(self):
-        assert self.project.project_url_param == "CMIP6"
+    def test_facets_url_input4MIPS(self):
+        project = ProjectFactory.create(name="input4MIPs")  # type: Project
+
+        assert "activity_id=input4MIPs" in project.facets_url
+
+    def test_project_param_success(self):
+        assert self.project.project_param == {"project": "CMIP6"}
 
 
 class TestProjectFacetModel:


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR fixes the Search API query string for input4MIPs, which was returning the incorrect number of results.
The query string uses `activity_id=input4MIPs`, rather than `project=input4MIPs`. 

Additional updates
- Refactor project_param prop to use dict instead of if-else statement
- Add docstring for project_param

Fixes # (issue)

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [ ] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
