### PR TITLE
Combine user query related states into activeSearchQuery

### DIFF
--- a/frontend/src/api/mock/fixtures.ts
+++ b/frontend/src/api/mock/fixtures.ts
@@ -21,6 +21,7 @@ import {
   RawNodeStatus,
 } from '../../components/NodeStatus/types';
 import {
+  ActiveSearchQuery,
   RawCitation,
   RawSearchResult,
   RawSearchResults,
@@ -127,6 +128,18 @@ export const rawCitationFixture = (
   };
 
   return { ...defaults, ...props };
+};
+
+export const activeSearchQueryFixture = (
+  props: Partial<ActiveSearchQuery> = {}
+): ActiveSearchQuery => {
+  const defaults: ActiveSearchQuery = {
+    project: rawProjectFixture(),
+    resultType: 'all',
+    activeFacets: { foo: ['option1', 'option2'], baz: ['option1'] },
+    textInputs: ['foo'],
+  };
+  return { ...defaults, ...props } as ActiveSearchQuery;
 };
 
 export const userSearchQueryFixture = (

--- a/frontend/src/components/Facets/ProjectForm.test.tsx
+++ b/frontend/src/components/Facets/ProjectForm.test.tsx
@@ -1,17 +1,19 @@
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { projectsFixture } from '../../api/mock/fixtures';
+import {
+  activeSearchQueryFixture,
+  projectsFixture,
+} from '../../api/mock/fixtures';
 import ProjectsForm, { Props } from './ProjectForm';
 
 const defaultProps: Props = {
-  activeProject: { name: 'foo' },
-  activeFacets: { data_node: ['foo'] },
+  activeSearchQuery: activeSearchQueryFixture(),
   projectsIsLoading: false,
   projectsFetched: { results: projectsFixture() },
   onFinish: jest.fn(),
 };
 
-it('renders Popconfirm component when there is an activeProject and activeFacet(s)', () => {
+it('renders Popconfirm component when there is an active project and active facets', () => {
   const { getByRole, getByText } = render(<ProjectsForm {...defaultProps} />);
 
   // Click the submit button

--- a/frontend/src/components/Facets/ProjectForm.tsx
+++ b/frontend/src/components/Facets/ProjectForm.tsx
@@ -6,15 +6,15 @@ import Alert from '../Feedback/Alert';
 import Popconfirm from '../Feedback/Popconfirm';
 import Spin from '../Feedback/Spin';
 import Button from '../General/Button';
-import { ActiveFacets, RawProject, RawProjects } from './types';
+import { ActiveSearchQuery } from '../Search/types';
+import { RawProject, RawProjects } from './types';
 
 const styles = {
   form: { width: '256px' },
 };
 
 export type Props = {
-  activeProject: RawProject | Record<string, unknown>;
-  activeFacets: ActiveFacets | Record<string, unknown>;
+  activeSearchQuery: ActiveSearchQuery;
   projectsFetched?: {
     results: RawProjects;
   };
@@ -24,8 +24,7 @@ export type Props = {
 };
 
 const ProjectsForm: React.FC<Props> = ({
-  activeProject,
-  activeFacets,
+  activeSearchQuery,
   projectsFetched,
   projectsIsLoading,
   projectsError,
@@ -37,7 +36,7 @@ const ProjectsForm: React.FC<Props> = ({
    */
   React.useEffect(() => {
     projectForm.resetFields();
-  }, [projectForm, activeProject]);
+  }, [projectForm, activeSearchQuery.project]);
 
   // Note, have to wrap Alert and Spin with Form to suppress warning about
   // projectForm not being bound to a <Form/></Form> Instance
@@ -65,7 +64,8 @@ const ProjectsForm: React.FC<Props> = ({
   if (projectsFetched) {
     const { results } = projectsFetched;
     const initialValues = {
-      project: (activeProject as RawProject).name || results[0].name,
+      project:
+        (activeSearchQuery.project as RawProject).name || results[0].name,
     };
 
     return (
@@ -97,7 +97,8 @@ const ProjectsForm: React.FC<Props> = ({
             </Select>
           </Form.Item>
           <Form.Item>
-            {!objectIsEmpty(activeProject) && !objectIsEmpty(activeFacets) ? (
+            {!objectIsEmpty(activeSearchQuery.project) &&
+            !objectIsEmpty(activeSearchQuery.activeFacets) ? (
               <Popconfirm
                 title="Your filters will be cleared."
                 onConfirm={() => projectForm.submit()}

--- a/frontend/src/components/Facets/index.test.tsx
+++ b/frontend/src/components/Facets/index.test.tsx
@@ -1,18 +1,17 @@
 import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import {
+  activeSearchQueryFixture,
   defaultFacetsFixture,
   parsedFacetsFixture,
   parsedNodeStatusFixture,
-  rawProjectFixture,
 } from '../../api/mock/fixtures';
 import Facets, { Props } from './index';
 
 const defaultProps: Props = {
-  activeProject: rawProjectFixture(),
   defaultFacets: defaultFacetsFixture(),
-  activeFacets: {},
-  projectFacets: parsedFacetsFixture(),
+  activeSearchQuery: activeSearchQueryFixture(),
+  availableFacets: parsedFacetsFixture(),
   nodeStatus: parsedNodeStatusFixture(),
   onProjectChange: jest.fn(),
   onSetFacets: jest.fn(),
@@ -32,7 +31,10 @@ it('renders component', async () => {
 
 it('handles when the project form is submitted', async () => {
   const { getByTestId } = render(
-    <Facets {...defaultProps} activeProject={{}} />
+    <Facets
+      {...defaultProps}
+      activeSearchQuery={{ ...activeSearchQueryFixture(), project: {} }}
+    />
   );
 
   // Check FacetsForm component renders

--- a/frontend/src/components/Facets/index.tsx
+++ b/frontend/src/components/Facets/index.tsx
@@ -4,6 +4,7 @@ import { fetchProjects } from '../../api';
 import { objectIsEmpty } from '../../common/utils';
 import Divider from '../General/Divider';
 import { NodeStatusArray } from '../NodeStatus/types';
+import { ActiveSearchQuery } from '../Search/types';
 import FacetsForm from './FacetsForm';
 import ProjectForm from './ProjectForm';
 import { ActiveFacets, DefaultFacets, ParsedFacets, RawProject } from './types';
@@ -15,20 +16,18 @@ const styles = {
 };
 
 export type Props = {
-  activeProject: RawProject | Record<string, unknown>;
+  activeSearchQuery: ActiveSearchQuery;
   defaultFacets: DefaultFacets;
-  activeFacets: ActiveFacets | Record<string, unknown>;
-  projectFacets: ParsedFacets | Record<string, unknown>;
+  availableFacets: ParsedFacets | Record<string, unknown>;
   nodeStatus?: NodeStatusArray;
   onProjectChange: (selectedProj: RawProject) => void;
   onSetFacets: (defaults: DefaultFacets, active: ActiveFacets) => void;
 };
 
 const Facets: React.FC<Props> = ({
-  activeProject,
+  activeSearchQuery,
   defaultFacets,
-  activeFacets,
-  projectFacets,
+  availableFacets,
   nodeStatus,
   onProjectChange,
   onSetFacets,
@@ -50,24 +49,16 @@ const Facets: React.FC<Props> = ({
     }
   };
 
+  /**
+   * TODO: Add logic to handle new resultType form for replicas
+   */
   const handleUpdateFacetsForm = (selectedFacets: {
     [key: string]: string[] | [];
   }): void => {
     const newActive = selectedFacets;
-    const { selectedDefaults } = newActive;
-    delete newActive.selectedDefaults;
 
+    // TODO: Placeholder until DefaultFacets are removed
     const newDefaults: DefaultFacets = { latest: true, replica: false };
-
-    // Have to check if selected default facets is not undefined, otherwise a
-    // test fails because ant design's form's initialValues does not work after
-    // the initial detection of value changes.
-    /* istanbul ignore else */
-    if (selectedDefaults) {
-      selectedDefaults.forEach((facet) => {
-        newDefaults[facet] = true;
-      });
-    }
 
     // The form keeps a history of all selected facets, including when a
     // previously selected key goes from > 0 elements to 0 elements. Thus,
@@ -86,8 +77,7 @@ const Facets: React.FC<Props> = ({
       <h2>Select a Project</h2>
       <div data-testid="projectForm">
         <ProjectForm
-          activeProject={activeProject}
-          activeFacets={activeFacets}
+          activeSearchQuery={activeSearchQuery}
           projectsFetched={data}
           projectsIsLoading={isLoading}
           projectsError={error}
@@ -95,14 +85,13 @@ const Facets: React.FC<Props> = ({
         />
         <Divider />
       </div>
-      {!objectIsEmpty(projectFacets) && (
+      {!objectIsEmpty(availableFacets) && (
         <>
           <h2>Filter with Facets</h2>
           <FacetsForm
-            facetsByGroup={(activeProject as RawProject).facetsByGroup}
+            activeSearchQuery={activeSearchQuery}
             defaultFacets={defaultFacets}
-            activeFacets={activeFacets}
-            projectFacets={projectFacets as ParsedFacets}
+            availableFacets={availableFacets as ParsedFacets}
             nodeStatus={nodeStatus}
             onValuesChange={handleUpdateFacetsForm}
           />

--- a/frontend/src/components/NavBar/LeftMenu.test.tsx
+++ b/frontend/src/components/NavBar/LeftMenu.test.tsx
@@ -5,10 +5,8 @@ import { projectsFixture } from '../../api/mock/fixtures';
 import LeftMenu, { Props } from './LeftMenu';
 
 const defaultProps: Props = {
-  activeProject: { name: 'test1' },
   projects: projectsFixture(),
   onTextSearch: jest.fn(),
-  onProjectChange: jest.fn(),
 };
 
 it('renders search input', () => {
@@ -44,32 +42,4 @@ it('successfully submits search form and resets current text with onFinish', asy
 
   // Check if the input value resets back to blank
   await waitFor(() => expect(input.value).toEqual(''));
-});
-
-it('successfully submits search form and resets current text with onFinish, and updates activeProject when activeProject !== selectedProj', async () => {
-  const onProjectChange = jest.fn();
-  const { getByPlaceholderText, getByRole } = render(
-    <Router>
-      <LeftMenu
-        {...defaultProps}
-        activeProject={{}}
-        onProjectChange={onProjectChange}
-      />
-    </Router>
-  );
-
-  // Change form field values
-  const input = getByPlaceholderText(
-    'Search for a keyword'
-  ) as HTMLInputElement;
-  fireEvent.change(input, { target: { value: 'Solar' } });
-  expect(input.value).toEqual('Solar');
-
-  // Submit the form
-  const submitBtn = getByRole('img', { name: 'search' });
-  fireEvent.submit(submitBtn);
-
-  // Check if the input value resets back to blank
-  await waitFor(() => expect(input.value).toEqual(''));
-  expect(onProjectChange).toHaveBeenCalled();
 });

--- a/frontend/src/components/NavBar/LeftMenu.tsx
+++ b/frontend/src/components/NavBar/LeftMenu.tsx
@@ -10,18 +10,11 @@ const styles = {
 };
 
 export type Props = {
-  activeProject: RawProject | Record<string, unknown>;
   projects: RawProjects;
-  onTextSearch: (text: string) => void;
-  onProjectChange: (selectedProj: RawProject) => void;
+  onTextSearch: (selectedProject: RawProject, text: string) => void;
 };
 
-const LeftMenu: React.FC<Props> = ({
-  activeProject,
-  projects,
-  onTextSearch,
-  onProjectChange,
-}) => {
+const LeftMenu: React.FC<Props> = ({ projects, onTextSearch }) => {
   const [form] = Form.useForm();
   const [text, setText] = React.useState('');
   const history = useHistory();
@@ -40,12 +33,7 @@ const LeftMenu: React.FC<Props> = ({
       (obj) => obj.name === values.projectTextInput
     );
 
-    /* istanbul ignore else */
-    if (selectedProj && activeProject !== selectedProj) {
-      onProjectChange(selectedProj);
-    }
-
-    onTextSearch(values.text);
+    onTextSearch(selectedProj as RawProject, values.text);
 
     // Reset the controlled state and form field
     setText('');

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -18,19 +18,15 @@ const styles = {
 };
 
 export type Props = {
-  activeProject: RawProject | Record<string, unknown>;
   numCartItems: number;
   numSavedSearches: number;
-  onProjectChange: (selectedProj: RawProject) => void;
-  onTextSearch: (text: string) => void;
+  onTextSearch: (selectedProject: RawProject, text: string) => void;
 };
 
 const NavBar: React.FC<Props> = ({
-  activeProject,
   numCartItems,
   numSavedSearches,
   onTextSearch,
-  onProjectChange,
 }) => {
   const { data, error, isLoading } = useAsync(fetchProjects);
   const [showDrawer, setShowDrawer] = React.useState(false);
@@ -65,10 +61,8 @@ const NavBar: React.FC<Props> = ({
           )}
           {data && (
             <LeftMenu
-              activeProject={activeProject}
               projects={data.results}
               onTextSearch={onTextSearch}
-              onProjectChange={onProjectChange}
             ></LeftMenu>
           )}
         </div>

--- a/frontend/src/components/Search/index.test.tsx
+++ b/frontend/src/components/Search/index.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import {
+  activeSearchQueryFixture,
   defaultFacetsFixture,
   ESGFSearchAPIFixture,
   rawSearchResultFixture,
@@ -19,15 +20,13 @@ import Search, {
 import { RawSearchResult, TextInputs } from './types';
 
 const defaultProps: Props = {
-  activeProject: { name: 'foo', facetsUrl: 'https://fubar.gov/?' },
+  activeSearchQuery: activeSearchQueryFixture(),
   defaultFacets: defaultFacetsFixture(),
-  activeFacets: { foo: ['option1', 'option2'], baz: ['option1'] },
-  textInputs: ['foo'],
   userCart: [],
   onRemoveFilter: jest.fn(),
   onClearFilters: jest.fn(),
   onUpdateCart: jest.fn(),
-  onUpdateProjectFacets: jest.fn(),
+  onUpdateAvailableFacets: jest.fn(),
   onSaveSearchQuery: jest.fn(),
 };
 
@@ -89,7 +88,7 @@ describe('test Search component', () => {
     // Check for stringified filters text
     const strFilters = await waitFor(() =>
       getByRole('heading', {
-        name: '2 results found for foo',
+        name: '2 results found for test1',
       })
     );
 

--- a/frontend/src/components/Search/types.ts
+++ b/frontend/src/components/Search/types.ts
@@ -1,3 +1,6 @@
+import { ActiveFacets , RawProject } from '../Facets/types';
+
+
 export type TextInputs = string[];
 
 export type RawCitation = {
@@ -8,6 +11,15 @@ export type RawCitation = {
   publicationYear: number;
   identifierDOI: string;
   creatorsList: string;
+};
+
+export type ResultType = 'all' | 'originalsOnly' | 'replicasOnly';
+
+export type ActiveSearchQuery = {
+  project: RawProject | Record<string, unknown>;
+  resultType: ResultType;
+  activeFacets: ActiveFacets | Record<string, unknown>;
+  textInputs: TextInputs | [];
 };
 
 export type RawSearchResult = {


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR combines the `activeProject`, `activeFacets`, and `textInputs` states related to a user's query into a single `activeSearchQuery` state for cleaner state management.

Fixes # (issue)
- #197 

## Type of change

<!--
  Please delete options that are not relevant.
-->

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [ ] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
