### PR TITLE
Add technical notes and supplemental data links

### DIFF
--- a/frontend/src/api/mock/fixtures.ts
+++ b/frontend/src/api/mock/fixtures.ts
@@ -66,6 +66,7 @@ export const rawSearchResultFixture = (
     size: 1,
     access: ['HTTPServer', 'OPeNDAP', 'Globus'],
     citation_url: ['https://foo.bar'],
+    xlink: ['url.com|PID|pid'],
   };
   return { ...defaults, ...props };
 };

--- a/frontend/src/common/utils.test.ts
+++ b/frontend/src/common/utils.test.ts
@@ -36,10 +36,13 @@ describe('Test splitURLbyChar', () => {
     url = 'first.com|second.com';
   });
   it('returns first half of the split', () => {
-    expect(splitURLByChar(url, '|', 'first')).toEqual('first.com');
+    expect(splitURLByChar(url, '|', '0') as string).toEqual('first.com');
   });
   it('returns second half of the split', () => {
-    expect(splitURLByChar(url, '|', 'second')).toEqual('second.com');
+    expect(splitURLByChar(url, '|', '1') as string).toEqual('second.com');
+  });
+  it('throws error if index does not exist', () => {
+    expect(() => splitURLByChar(url, '|', '2') as string).toThrow();
   });
 });
 describe('Test formatBytes', () => {

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -18,17 +18,31 @@ export const objectHasKey = (
 };
 
 /**
- * Parses urls to remove characters following the specified character
+ * Parses urls to split strings following the specified character.
+ *
+ * For a record's 'xlink' attribute, it will be split into an array of
+ * three strings.
+ *
+ * xlink URL example: 'http://cera-www.dkrz.de/WDCC/meta/CMIP6/CMIP6.ScenarioMIP.CCCma.CanESM5.ssp126.r12i1p2f1.day.clt.gn.v20190429.json|Citation|citation'
+ * Output split by '|': ['http://cera-www.dkrz.de/WDCC/meta/CMIP6/CMIP6.ScenarioMIP.CCCma.CanESM5.ssp126.r12i1p2f1.day.clt.gn.v20190429.json', 'Citation', 'citation])
+ *
  */
 export const splitURLByChar = (
   url: string,
-  char: string,
-  returnHalf: 'first' | 'second'
-): string => {
-  if (returnHalf === 'first') {
-    return url.split(char)[0];
+  char: '|' | '.json',
+  returnIndex?: '0' | '1' | '2'
+): string[] | string => {
+  const splitURL = url.split(char);
+
+  if (returnIndex) {
+    const returnIndexNum = Number(returnIndex);
+    if (splitURL[returnIndexNum] === undefined) {
+      throw new Error('Index does not exist in array of URLs');
+    }
+    return splitURL[returnIndexNum];
   }
-  return url.split(char)[1];
+
+  return splitURL;
 };
 
 /**

--- a/frontend/src/components/App/App.test.tsx
+++ b/frontend/src/components/App/App.test.tsx
@@ -340,7 +340,7 @@ describe('User cart', () => {
     const firstRow = await waitFor(() =>
       getByRole('row', {
         name:
-          'right-circle bar 2 1 Bytes close-circle esgf1.dkrz.de 1 wget download plus',
+          'right-circle bar 2 1 Bytes close-circle esgf1.dkrz.de 1 wget download PID plus',
       })
     );
     expect(firstRow).toBeTruthy();
@@ -457,7 +457,7 @@ describe('User cart', () => {
     const firstRow = await waitFor(() =>
       getByRole('row', {
         name:
-          'right-circle foo 3 1 Bytes check-circle aims3.llnl.gov 1 wget download plus',
+          'right-circle foo 3 1 Bytes check-circle aims3.llnl.gov 1 wget download PID plus',
       })
     );
     expect(firstRow).toBeTruthy();
@@ -506,7 +506,7 @@ describe('User cart', () => {
     const firstRow = await waitFor(() =>
       getByRole('row', {
         name:
-          'right-circle foo 3 1 Bytes check-circle aims3.llnl.gov 1 wget download plus',
+          'right-circle foo 3 1 Bytes check-circle aims3.llnl.gov 1 wget download PID plus',
       })
     );
     expect(firstRow).toBeTruthy();

--- a/frontend/src/components/Cart/Items.test.tsx
+++ b/frontend/src/components/Cart/Items.test.tsx
@@ -50,7 +50,7 @@ it('handles selecting items in the cart and downloading them via wget', async ()
   // Check first row renders and click the checkbox
   const firstRow = getByRole('row', {
     name:
-      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download minus',
+      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download PID minus',
   });
   const firstCheckBox = within(firstRow).getByRole('checkbox');
   expect(firstCheckBox).toBeTruthy();
@@ -90,7 +90,7 @@ it('handles error selecting items in the cart and downloading them via wget', as
   // Check first row renders and click the checkbox
   const firstRow = getByRole('row', {
     name:
-      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download minus',
+      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download PID minus',
   });
   const firstCheckBox = within(firstRow).getByRole('checkbox');
   expect(firstCheckBox).toBeTruthy();

--- a/frontend/src/components/Search/Citation.tsx
+++ b/frontend/src/components/Search/Citation.tsx
@@ -37,7 +37,7 @@ const Citation: React.FC<CitationProps> = ({ url }) => {
     <div>
       <div>
         <a
-          href={splitURLByChar(url, '.json', 'first')}
+          href={splitURLByChar(url, '.json', '0') as string}
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/frontend/src/components/Search/FilesTable.tsx
+++ b/frontend/src/components/Search/FilesTable.tsx
@@ -32,7 +32,7 @@ export const genDownloadUrls = (urls: string[]): DownloadUrls => {
   const newUrls: DownloadUrls = [];
   urls.forEach((url) => {
     const downloadType = url.split('|').pop();
-    let downloadUrl = splitURLByChar(url, '|', 'first');
+    let downloadUrl = splitURLByChar(url, '|', '0') as string;
 
     if (downloadType === 'OPeNDAP') {
       downloadUrl = downloadUrl.replace('.html', '.dods');

--- a/frontend/src/components/Search/Table.test.tsx
+++ b/frontend/src/components/Search/Table.test.tsx
@@ -43,7 +43,7 @@ it('renders record metadata in an expandable panel', async () => {
   // Check a record row exist
   const row = getByRole('row', {
     name:
-      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download plus',
+      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download PID plus',
   });
   expect(row).toBeTruthy();
 
@@ -94,7 +94,7 @@ it('renders "PID" button when the record has a "xlink" key/value, vice versa', (
   const results = [...defaultProps.results];
   results[0] = {
     ...results[0],
-    xlink: ['https://foo.bar|', 'https://foo.bar|'],
+    xlink: ['https://foo.bar|PID|pid', 'https://foo.bar|'],
     further_info_url: ['https://foo.bar'],
   };
 
@@ -116,19 +116,6 @@ it('renders "PID" button when the record has a "xlink" key/value, vice versa', (
   const firstInfoBtn = within(firstRow).getByText('ES-DOC');
   expect(firstPidBtn).toBeTruthy();
   expect(firstInfoBtn).toBeTruthy();
-
-  // Check second row exists
-  const secondRow = getByRole('row', {
-    name:
-      'right-circle bar 2 1 Bytes question-circle esgf1.dkrz.de 1 wget download plus',
-  });
-  expect(secondRow).toBeTruthy();
-
-  // Check both PID and ES-DOC buttons did not render for the second row
-  const qPidBtn = within(secondRow).queryByText('PID');
-  expect(qPidBtn).toBeNull();
-  const qInfoBtn = within(secondRow).queryByText('ES-DOC');
-  expect(qInfoBtn).toBeNull();
 });
 
 it('renders add or remove button for items in or not in the cart respectively, and handles clicking them', () => {
@@ -143,7 +130,7 @@ it('renders add or remove button for items in or not in the cart respectively, a
   // Check first row exists
   const firstRow = getByRole('row', {
     name:
-      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download minus',
+      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download PID minus',
   });
   expect(firstRow).toBeTruthy();
 
@@ -155,7 +142,7 @@ it('renders add or remove button for items in or not in the cart respectively, a
   // Check second row exists
   const secondRow = getByRole('row', {
     name:
-      'right-circle bar 2 1 Bytes question-circle esgf1.dkrz.de 1 wget download plus',
+      'right-circle bar 2 1 Bytes question-circle esgf1.dkrz.de 1 wget download PID plus',
   });
   expect(secondRow).toBeTruthy();
 
@@ -175,7 +162,7 @@ it('handles when clicking the select checkbox for a row', () => {
   // Check a record row exist
   const row = getByRole('row', {
     name:
-      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download plus',
+      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download PID plus',
   });
   expect(row).toBeTruthy();
 
@@ -220,7 +207,7 @@ it('handles downloading an item via wget', async () => {
   // Check first row renders
   const firstRow = getByRole('row', {
     name:
-      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download minus',
+      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download PID minus',
   });
   expect(firstRow).toBeTruthy();
 
@@ -250,7 +237,7 @@ it('displays an error when unable to access download via wget', async () => {
   // Check first row renders
   const firstRow = getByRole('row', {
     name:
-      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download minus',
+      'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download PID minus',
   });
   expect(firstRow).toBeTruthy();
 

--- a/frontend/src/components/Search/index.test.tsx
+++ b/frontend/src/components/Search/index.test.tsx
@@ -199,7 +199,7 @@ describe('test Search component', () => {
     // Select the first row
     const firstRow = getByRole('row', {
       name:
-        'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download plus',
+        'right-circle foo 3 1 Bytes question-circle aims3.llnl.gov 1 wget download PID plus',
     });
     expect(firstRow).toBeTruthy();
 


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR adds support for technical notes and supplemental data links (specifically obs4MIPS) under the 'Additional' column of the search results table.

Summary of Changes
- Add xlinkTypesToOutput object to determine which xlinks to output as buttons
- Update rawSearchResult fixture to include xlink array
- Update tests for 100% coverage
- Update splitURLByChar to support multiple return types, including entire array or specific indexes
- Closes #194


Fixes # (issue)
- #194 

## Type of change

<!--
  Please delete options that are not relevant.
-->

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
