### PR TITLE
Add handle for datasets without size or number_of_files attrs

### DIFF
--- a/frontend/src/components/Cart/Summary.test.tsx
+++ b/frontend/src/components/Cart/Summary.test.tsx
@@ -1,14 +1,17 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { userCartFixture } from '../../api/mock/fixtures';
+import {
+  rawSearchResultFixture,
+  userCartFixture,
+} from '../../api/mock/fixtures';
 import Summary, { Props } from './Summary';
 
 const defaultProps: Props = {
   userCart: userCartFixture(),
 };
 
-test('renders without crashing', () => {
+test('renders component', () => {
   const { getByTestId } = render(
     <Router>
       <Summary {...defaultProps} />
@@ -29,5 +32,28 @@ it('shows the correct number of datasets and files', () => {
   ).toBeTruthy();
   expect(
     getByText((_, node) => node.textContent === 'Number of Files: 5')
+  ).toBeTruthy();
+});
+
+it('renders component with correct calculations when a dataset doesn"t have size or number_of_files attributes', () => {
+  const { getByText } = render(
+    <Router>
+      <Summary
+        userCart={[
+          rawSearchResultFixture(),
+          rawSearchResultFixture({
+            size: undefined,
+            number_of_files: undefined,
+          }),
+        ]}
+      />
+    </Router>
+  );
+  // Shows number of files
+  expect(
+    getByText((_, node) => node.textContent === 'Number of Datasets: 2')
+  ).toBeTruthy();
+  expect(
+    getByText((_, node) => node.textContent === 'Number of Files: 3')
   ).toBeTruthy();
 });

--- a/frontend/src/components/Cart/Summary.tsx
+++ b/frontend/src/components/Cart/Summary.tsx
@@ -26,12 +26,13 @@ const Summary: React.FC<Props> = ({ userCart }) => {
   let totalDataSize = '0';
   if (userCart.length > 0) {
     numFiles = (userCart as RawSearchResults).reduce(
-      (acc: number, dataset: RawSearchResult) => acc + dataset.number_of_files,
+      (acc: number, dataset: RawSearchResult) =>
+        acc + (dataset.number_of_files || 0),
       0
     );
 
     const rawDataSize = (userCart as RawSearchResults).reduce(
-      (acc: number, dataset: RawSearchResult) => acc + dataset.size,
+      (acc: number, dataset: RawSearchResult) => acc + (dataset.size || 0),
       0
     );
     totalDataSize = formatBytes(rawDataSize);

--- a/frontend/src/components/Search/Table.test.tsx
+++ b/frontend/src/components/Search/Table.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import React from 'react';
-import { rawSearchResultsFixture } from '../../api/mock/fixtures';
+import {
+  rawSearchResultFixture,
+  rawSearchResultsFixture,
+} from '../../api/mock/fixtures';
 import { rest, server } from '../../api/mock/setup-env';
 import apiRoutes from '../../api/routes';
 import Table, { Props, QualityFlag } from './Table';
@@ -31,6 +34,28 @@ it('renders component without results', () => {
 
   const noDataText = getByText('No Data');
   expect(noDataText).toBeTruthy();
+});
+
+it('renders not available for total size and number of files columns when dataset doesn"t have those attributes', () => {
+  const { getByRole } = render(
+    <Table
+      {...defaultProps}
+      results={[
+        rawSearchResultFixture({ size: undefined, number_of_files: undefined }),
+      ]}
+    />
+  );
+
+  // Check table exists
+  const table = getByRole('table');
+  expect(table).toBeTruthy();
+
+  // Check a record row exist
+  const row = getByRole('row', {
+    name:
+      'right-circle foo N/A N/A question-circle aims3.llnl.gov 1 wget download PID plus',
+  });
+  expect(row).toBeTruthy();
 });
 
 it('renders record metadata in an expandable panel', async () => {

--- a/frontend/src/components/Search/Table.tsx
+++ b/frontend/src/components/Search/Table.tsx
@@ -161,14 +161,14 @@ const Table: React.FC<Props> = ({
       dataIndex: 'number_of_files',
       key: 'number_of_files',
       width: 100,
-      render: (numberOfFiles: number) => <p>{numberOfFiles}</p>,
+      render: (numberOfFiles: number) => <p>{numberOfFiles || 'N/A'}</p>,
     },
     {
       title: 'Total Size',
       dataIndex: 'size',
       key: 'size',
       width: 100,
-      render: (size: number) => <p>{formatBytes(size)}</p>,
+      render: (size: number) => <p>{size ? formatBytes(size) : 'N/A'}</p>,
     },
     {
       title: 'Node',

--- a/frontend/src/components/Search/types.ts
+++ b/frontend/src/components/Search/types.ts
@@ -32,8 +32,8 @@ export type RawSearchResult = {
   xlink?: string[] | [];
   citation_url?: string[] | [];
   further_info_url?: string[] | [];
-  number_of_files: number;
-  size: number;
+  number_of_files?: number;
+  size?: number;
   [key: string]: string | string[] | number | undefined;
 };
 


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR adds handles for rendering datasets without `size` or `number_of_files` attributes set, which is most common in obs4MIPs data.

Fixes # (issue)
- Closes #227

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [ ] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
