### PR TITLE
Add network-timeout to react production Dockerfile

### DIFF
--- a/frontend/docker/production/react/Dockerfile
+++ b/frontend/docker/production/react/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH /app/node_modules/.bin:$PATH
 # Install app dependencies
 COPY package.json ./
 COPY yarn.lock ./
-RUN yarn install --frozen-lock-file
+RUN yarn install --frozen-lock-file --network-timeout=1000000
 
 # Add app
 COPY . ./


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR adds the `network-timeout` param for yarn which elongates the timeout when fetching packages. Without it, yarn would timeout in <10 secs on the host server when fetching packages. This may be caused by large packages that take longer to fetch.

Fixes # (issue)
N/A

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [ ] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
