### PR TITLE
Add default value for numResults in FilesTable

### DIFF
--- a/frontend/src/components/Search/FilesTable.tsx
+++ b/frontend/src/components/Search/FilesTable.tsx
@@ -43,11 +43,11 @@ export const genDownloadUrls = (urls: string[]): DownloadUrls => {
 };
 export type Props = {
   id: string;
-  numResults: number;
+  numResults?: number;
   filenameVars?: TextInputs | [];
 };
 
-const FilesTable: React.FC<Props> = ({ id, numResults, filenameVars }) => {
+const FilesTable: React.FC<Props> = ({ id, numResults = 0, filenameVars }) => {
   // Add options to this constant as needed.
   type FileDownloadTypes = 'HTTPServer' | 'OpeNDAP' | 'Globus';
   // This variable populates the download drop downs and is used in conditionals.


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR fixes the TypeScript type error for `numResults` in the `FilesTable` component

Fixes # (issue)
N/A

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
