### PR TITLE
Fix node status API returning a response without node status data causing crash

### DIFF
--- a/frontend/src/components/App/App.test.tsx
+++ b/frontend/src/components/App/App.test.tsx
@@ -397,12 +397,15 @@ describe('User cart', () => {
     const cartSummary = await waitFor(() => getByTestId('summary'));
     expect(cartSummary).toBeTruthy();
 
-    expect(
+    const numDatasetsText = await waitFor(() =>
       getByText((_, node) => node.textContent === 'Number of Datasets: 1')
-    ).toBeTruthy();
-    expect(
+    );
+    expect(numDatasetsText).toBeTruthy();
+
+    const numFilesText = await waitFor(() =>
       getByText((_, node) => node.textContent === 'Number of Files: 3')
-    ).toBeTruthy();
+    );
+    expect(numFilesText).toBeTruthy();
 
     // Check "Remove All Items" button renders with cart > 0 items and click it
     const clearCartBtn = within(cart).getByRole('button', {

--- a/frontend/src/components/NodeStatus/index.test.tsx
+++ b/frontend/src/components/NodeStatus/index.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import NodeStatus, { Props } from '.';
 import { ResponseError } from '../../api';
 import { parsedNodeStatusFixture } from '../../api/mock/fixtures';
+import apiRoutes from '../../api/routes';
 
 const defaultProps: Props = {
   nodeStatus: parsedNodeStatusFixture(),
@@ -56,6 +57,39 @@ it('renders an error message when there is an api error', async () => {
       isLoading={false}
       apiError={Error(errorMsg) as ResponseError}
     ></NodeStatus>
+  );
+
+  const alertMsg = await waitFor(() =>
+    getByRole('img', { name: 'close-circle', hidden: true })
+  );
+  expect(alertMsg).toBeTruthy();
+
+  const errorMsgDiv = getByText(errorMsg);
+  expect(errorMsgDiv).toBeTruthy();
+});
+
+it('renders error message that feature is disabled', async () => {
+  const errorMsg =
+    'This feature is not enabled on this node or status information is currently unavailable.';
+
+  const { getByRole, getByText } = render(
+    <NodeStatus isLoading={false} nodeStatus={[]}></NodeStatus>
+  );
+
+  const alertMsg = await waitFor(() =>
+    getByRole('img', { name: 'close-circle', hidden: true })
+  );
+  expect(alertMsg).toBeTruthy();
+
+  const errorMsgDiv = getByText(errorMsg);
+  expect(errorMsgDiv).toBeTruthy();
+});
+
+it('renders fallback network error msg', async () => {
+  const errorMsg = apiRoutes.nodeStatus.handleErrorMsg('generic');
+
+  const { getByRole, getByText } = render(
+    <NodeStatus isLoading={false}></NodeStatus>
   );
 
   const alertMsg = await waitFor(() =>

--- a/frontend/src/components/NodeStatus/index.tsx
+++ b/frontend/src/components/NodeStatus/index.tsx
@@ -17,6 +17,10 @@ export type Props = {
 };
 
 const NodeStatus: React.FC<Props> = ({ nodeStatus, apiError, isLoading }) => {
+  // If the API returns a response but there is no data, that means the feature
+  // is disabled
+  const featureIsDisabled = nodeStatus && nodeStatus.length === 0;
+
   if (isLoading) {
     return (
       <>
@@ -35,7 +39,7 @@ const NodeStatus: React.FC<Props> = ({ nodeStatus, apiError, isLoading }) => {
   }
 
   /* istanbul ignore else */
-  if (nodeStatus) {
+  if (nodeStatus && !featureIsDisabled) {
     // Since the timestamp is the same for all node objects, use the first one
     const { timestamp } = nodeStatus[0];
 
@@ -118,15 +122,21 @@ const NodeStatus: React.FC<Props> = ({ nodeStatus, apiError, isLoading }) => {
     );
   }
 
-  let titleMsg = apiRoutes.nodeStatus.handleErrorMsg('generic');
+  let errorMsg: string;
+
   if (apiError) {
-    titleMsg = apiError.message;
+    errorMsg = apiError.message;
+  } else if (featureIsDisabled) {
+    errorMsg =
+      'This feature is not enabled on this node or status information is currently unavailable.';
+  } else {
+    errorMsg = apiRoutes.nodeStatus.handleErrorMsg('generic');
   }
 
   return (
     <>
       <TableD
-        title={() => <Alert message={titleMsg} type="error" />}
+        title={() => <Alert message={errorMsg} type="error" />}
         data-testid="nodeStatusTable"
         size="small"
         rowKey="name"

--- a/frontend/src/components/Search/FilesTable.test.tsx
+++ b/frontend/src/components/Search/FilesTable.test.tsx
@@ -42,6 +42,15 @@ const defaultProps: Props = {
 };
 
 describe('test FilesTable component', () => {
+  it('renders an empty data table when no results are available', async () => {
+    const { getByRole } = render(
+      <FilesTable {...defaultProps} numResults={undefined} />
+    );
+
+    const component = await waitFor(() => getByRole('table'));
+    expect(component).toBeTruthy();
+  });
+
   it('returns Alert when there is an error fetching files', async () => {
     server.use(
       rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) => {


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR fixes the node status page crashing when the feature is disabled. The node status API on prometheus will return a response if it is on, but will not return an array of node statuses if the feature itself is disabled.

Fixes # (issue)
- Closes #232 

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
