### PR TITLE
Minor updates to documentation.

### DIFF
--- a/docs/docs/contributors/architecture_design.md
+++ b/docs/docs/contributors/architecture_design.md
@@ -4,7 +4,7 @@ This page provides a high-level overview of the project architecture.
 
 ## Overview
 
-The project repo is a mono-repo split up between directories for the `front-end/`, `back-end/`, and `traefik/`. Although both sides of the stack are in a single repo, each directory contains its own microservices.
+The project repo is a mono-repo split up between directories for the `frontend/`, `backend/`, and `traefik/`. Although both sides of the stack are in a single repo, each directory contains its own microservices.
 
 **Why a mono-repo?**
 

--- a/docs/docs/contributors/frontend_development.md
+++ b/docs/docs/contributors/frontend_development.md
@@ -200,9 +200,17 @@ Run a command inside the docker container:
 docker-compose -p metagrid_local_frontend run --rm react [command]
 ```
 
-### `yarn start`
+### `yarn start:local`
 
-Runs the app in the development mode.<br />
+Runs the app in the development mode using `.local` environment settings.<br />
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+The page will reload if you make edits.<br />
+You will also see any lint errors in the console.
+
+### `yarn start:production`
+
+Runs the app in the development mode using `.production` environment settings.<br />
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 The page will reload if you make edits.<br />


### PR DESCRIPTION
## Description

One minor thing changed is on this page: https://metagrid.readthedocs.io/en/latest/contributors/architecture_design/#overview
I noticed the front-end and back-end folders show a hyphen whereas later down the page, they are correctly shown without the hyphen: front-end/ -> frontend. The hyphens are removed there, since it seems you're referring to the frontend/ and backend/ folders.

Fixes # (issue)

## Type of change

- This change is a documentation update

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build
