### PR TITLE
Fix overpopulation of download dropdowns for records

### DIFF
--- a/frontend/src/api/mock/fixtures.ts
+++ b/frontend/src/api/mock/fixtures.ts
@@ -79,7 +79,7 @@ export const rawSearchResultsFixture = (): Array<RawSearchResult> => {
       title: 'bar',
       number_of_files: 2,
       data_node: 'esgf1.dkrz.de',
-      access: ['HTTPServer', 'OPeNDAP'],
+      access: ['wget', 'HTTPServer', 'OPeNDAP'],
     }),
   ];
 };

--- a/frontend/src/components/Search/Table.tsx
+++ b/frontend/src/components/Search/Table.tsx
@@ -1,6 +1,4 @@
 import {
-  CheckCircleTwoTone,
-  CloseCircleTwoTone,
   DownCircleOutlined,
   DownloadOutlined,
   MinusOutlined,
@@ -80,10 +78,10 @@ const Table: React.FC<Props> = ({
   onPageChange,
   onPageSizeChange,
 }) => {
-  // Add options to this constant as needed.
+  // Add options to this constant as needed
   type DatasetDownloadTypes = 'wget' | 'Globus';
-  // This variable populates the download drop downs and is used in conditionals.
-  // TODO: Add 'Globus' during Globus integration process.
+  // If a record supports downloads from the allowed downloads, it will render
+  // in the drop downs
   const allowedDownloadTypes: DatasetDownloadTypes[] = ['wget'];
 
   const tableConfig = {
@@ -189,17 +187,8 @@ const Table: React.FC<Props> = ({
       key: 'download',
       width: 200,
       render: (record: RawSearchResult) => {
-        const { id } = record;
-
-        // Unique key for the download form item
-        const formKey = `download-${id}`;
-        let globusCompatible = false;
-        record.access.forEach((download) => {
-          if (download === 'Globus') {
-            globusCompatible = true;
-            allowedDownloadTypes.push('Globus');
-          }
-        });
+        const supportedDownloadTypes = record.access;
+        const formKey = `download-${record.id}`;
 
         /**
          * Handle the download form for datasets
@@ -226,15 +215,6 @@ const Table: React.FC<Props> = ({
 
         return (
           <>
-            {/* TODO: Remove display styling when Globus is integrated*/}
-            <p style={{ display: 'none' }}>
-              {globusCompatible ? (
-                <CheckCircleTwoTone twoToneColor="#52c41a" />
-              ) : (
-                <CloseCircleTwoTone twoToneColor="#eb2f96" />
-              )}{' '}
-              Globus Compatible
-            </p>
             <Form
               layout="inline"
               onFinish={({ [formKey]: download }) =>
@@ -244,11 +224,18 @@ const Table: React.FC<Props> = ({
             >
               <Form.Item name={formKey}>
                 <Select style={{ width: 120 }}>
-                  {allowedDownloadTypes.map((option) => (
-                    <Select.Option key={option} value={option}>
-                      {option}
-                    </Select.Option>
-                  ))}
+                  {allowedDownloadTypes.map(
+                    (option) =>
+                      (supportedDownloadTypes.includes(option) ||
+                        option === 'wget') && (
+                        <Select.Option
+                          key={`${formKey}-${option}`}
+                          value={option}
+                        >
+                          {option}
+                        </Select.Option>
+                      )
+                  )}
                 </Select>
               </Form.Item>
               <Form.Item>
@@ -268,8 +255,8 @@ const Table: React.FC<Props> = ({
       key: 'additional',
       width: 200,
       render: (record: RawSearchResult) => {
-        // Have to parse and format since 'xlink' attribute is
-        // poorly structured in the Search API
+        // Have to parse and format since 'xlink' attribute is poorly structured
+        // in the Search API
         const xlinkTypesToOutput: Record<
           string,
           { label: string; url: null | string }


### PR DESCRIPTION
## Description

This PR fixes the overpopulation of download dropdowns for records, specifically with the 'Globus' string.

- This issue was caused by the `allowedDownloadTypes` being appended with `Globus` for each record (dataset) that supported `Globus`
- The fix was to iterate over the `allowedDownloadTypes`, and check if the record"s `access` array supports the download type for rendering

Additional Changes
Remove Globus references -- can be integrated as a feature during Globus integration
- Removed pre-existing Globus compatibility icon code 
- Remove conditionals to check for Globus compatibility

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Fixes # (issue)
- Closes #253 

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
