### PR TITLE
Add VSCode `settings.json` to standardize IDE configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,79 @@
+{
+  // Project-wide VSCode Settings
+  // Python
+  // -----------------------------
+  "[python]": {
+    "editor.rulers": [72, 79, 120],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 120,
+    "editor.defaultFormatter": "ms-python.python"
+  },
+  // Update as needed
+  "python.pythonPath": "backend/venv/bin/python",
+  // Update as needed
+  "python.autoComplete.extraPaths": ["backend/venv/bin/python"],
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Args": ["--config=backend/setup.cfg"],
+  "python.formatting.provider": "black",
+  "python.linting.mypyEnabled": true,
+  // JavaScript
+  // -----------------------------
+  "javascript.updateImportsOnFileMove.enabled": "always",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 100],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100
+  },
+  // React
+  // -----------------------------
+  "files.exclude": {
+    "frontend/src/react-app-env.d.ts": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 100],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100
+  },
+  // TypeScript
+  // -----------------------------
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 100],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 100],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100
+  },
+  "typescript.updateImportsOnFileMove.enabled": "always",
+  // ESLint
+  // -----------------------------
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  // Jest
+  // -----------------------------
+  "jest.pathToJest": "yarn test:watch",
+  // HTML, CSS, JSON
+  // -----------------------------
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,3 +1,19 @@
 {
-    "python.pythonPath": "venv/bin/python"
+  // Back-end Workspace VSCode Settings
+  // Python
+  // -----------------------------
+  "[python]": {
+    "editor.rulers": [72, 79, 120],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 120,
+    "editor.defaultFormatter": "ms-python.python"
+  },
+  // Update as needed
+  "python.pythonPath": "venv/bin/python",
+  // Update as needed
+  "python.autoComplete.extraPaths": ["${workspaceFolder}/venv/bin/python"],
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Args": ["--config=setup.cfg"],
+  "python.formatting.provider": "black",
+  "python.linting.mypyEnabled": true
 }

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,63 @@
+{
+  // Front-end Workspace VSCode Settings
+  // JavaScript
+  // -----------------------------
+  "javascript.updateImportsOnFileMove.enabled": "always",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 100],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100
+  },
+  // React
+  // -----------------------------
+  "files.exclude": {
+    "src/react-app-env.d.ts": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 100],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100
+  },
+  // TypeScript
+  // -----------------------------
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 100],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 100],
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 100
+  },
+  "typescript.updateImportsOnFileMove.enabled": "always",
+  // ESLint
+  // -----------------------------
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  // Jest
+  // -----------------------------
+  "jest.pathToJest": "yarn test:watch",
+  // HTML, CSS, JSON
+  // -----------------------------
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This PR adds multiple `settings.json` files for VSCode to standardize IDE configurations for future contributors.
It configures VSCode to leverage the project's linters (Flake8, ESLint), formatters (Black, Prettier), and `mypy` for optional static type checking. It also configures editor rulers as guidance for line lengths and line wrapping.

There are three `settings.json` files: 1 for the entire project if you're not using VSCode workspaces, and 1 each for `/backend` and `/frontend` if you're using VSCode workspaces.

Fixes # (issue)
- Closes #261 

## Type of change

<!--
  Please delete options that are not relevant.
-->

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Pre-commit (ESLint, Prettier, Flake8, Black, Mypy)
- [x] CI/CD Build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
