### PR TITLE
Hotfix for copied URL path

### DIFF
--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -75,7 +75,7 @@ export const formatBytes = (bytes: number, decimals = 2): string => {
 
 export const getUrlFromSearch = (search: ActiveSearchQuery): string => {
   const urlString = `${window.location.protocol}${window.location.host}
-  /search/`;
+  ${window.location.pathname}`;
 
   if (!search.project) {
     return urlString;


### PR DESCRIPTION
Updated the getUrlFromSearch function so that the current path is included as a variable. This fixes issue in production where the generated URL was not working if a path-prefix was configured, for example 'metagrid' prefix.

- Bug fix (non-breaking change which fixes an issue)

- [ x] Local Pre-commit Checks
- [ x] CI/CD Build

## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
