### PR TITLE
Quick-fix for main tutorial text.

### DIFF
--- a/frontend/src/common/reactJoyrideSteps.ts
+++ b/frontend/src/common/reactJoyrideSteps.ts
@@ -297,7 +297,7 @@ export const createMainPageTour = (): JoyrideTour => {
   const tour = new JoyrideTour(TourTitles.Main)
     .addNextStep(
       'body',
-      "Welcome to Metagrid! This tour will highlight the main controls and features of the search page. During the tour, click 'Next' to continue, or 'Previous' to go back a step in the tour. Click 'Skip' if you wish to cancel the tour. Let's begin!",
+      "Welcome to Metagrid! This tour will highlight the main controls and features of the search page. During the tour, click 'Next' to continue, or 'Skip' if you wish to cancel the tour. Let's begin!",
       'center'
     )
     .addNextStep(


### PR DESCRIPTION
## Description

Quick update to remove reference to 'Previous' button in joyride tours since they were removed.
