### PR TITLE
Indicating a dataset is retracted

### DIFF
--- a/frontend/src/api/index.test.ts
+++ b/frontend/src/api/index.test.ts
@@ -284,6 +284,25 @@ describe('test fetching citation', () => {
     });
     expect(newCitation).toEqual(results);
   });
+  it('returns results with different creators', async () => {
+    const citation = rawCitationFixture();
+    const results = {
+      ...citation,
+      creators: [
+        { creatorName: 'Bobby' },
+        { creatorName: 'Tommy' },
+        { creatorName: 'Timmy' },
+        { creatorName: 'Joey' },
+      ],
+      identifierDOI: 'http://doi.org/an_id',
+      creatorsList: 'Bobby; Tommy; Timmy; et al.',
+    };
+
+    const newCitation = await fetchDatasetCitation({
+      url: 'citation_url?variant=b',
+    });
+    expect(newCitation).toEqual(results);
+  });
   it('catches and throws an error based on HTTP status code', async () => {
     server.use(
       rest.get(apiRoutes.citation.path, (_req, res, ctx) =>

--- a/frontend/src/api/mock/server-handlers.ts
+++ b/frontend/src/api/mock/server-handlers.ts
@@ -46,9 +46,43 @@ const handlers = [
   rest.get(apiRoutes.esgfSearch.path, (_req, res, ctx) =>
     res(ctx.status(200), ctx.json(ESGFSearchAPIFixture()))
   ),
-  rest.get(apiRoutes.citation.path, (_req, res, ctx) =>
-    res(ctx.status(200), ctx.json(rawCitationFixture()))
-  ),
+  rest.get(apiRoutes.citation.path, (_req, res, ctx) => {
+    // For testing more than one set of creators
+    const variant = _req.url.searchParams.get('variant');
+    if (variant) {
+      if (variant === 'a') {
+        return res(
+          ctx.status(200),
+          ctx.json(
+            rawCitationFixture({
+              creators: [
+                { creatorName: 'Bobby' },
+                { creatorName: 'Tommy' },
+                { creatorName: 'Joey' },
+              ],
+            })
+          )
+        );
+      }
+      if (variant === 'b') {
+        return res(
+          ctx.status(200),
+          ctx.json(
+            rawCitationFixture({
+              creators: [
+                { creatorName: 'Bobby' },
+                { creatorName: 'Tommy' },
+                { creatorName: 'Timmy' },
+                { creatorName: 'Joey' },
+              ],
+            })
+          )
+        );
+      }
+    }
+
+    return res(ctx.status(200), ctx.json(rawCitationFixture()));
+  }),
   rest.get(apiRoutes.wget.path, (_req, res, ctx) => res(ctx.status(200))),
   rest.get(apiRoutes.nodeStatus.path, (_req, res, ctx) =>
     res(ctx.status(200), ctx.json(rawNodeStatusFixture()))

--- a/frontend/src/components/Search/Citation.test.tsx
+++ b/frontend/src/components/Search/Citation.test.tsx
@@ -21,6 +21,36 @@ describe('test Citation component', () => {
     const citationCreators = await waitFor(() => getByText('Bob; Tom'));
     expect(citationCreators).toBeInTheDocument();
   });
+  it('renders component with 3 creators, no et al.', async () => {
+    const { getByRole, getByText } = render(
+      <Citation url="citation_url?variant=a" />
+    );
+
+    // Check for skeleton header, which indicates loading
+    const skeletonHeading = getByRole('heading');
+    expect(skeletonHeading).toBeTruthy();
+
+    // Check citation information rendered correctly
+    const citationCreators = await waitFor(() =>
+      getByText('Bobby; Tommy; Joey')
+    );
+    expect(citationCreators).toBeInTheDocument();
+  });
+  it('renders component with three creators and et al.', async () => {
+    const { getByRole, getByText } = render(
+      <Citation url="citation_url?variant=b" />
+    );
+
+    // Check for skeleton header, which indicates loading
+    const skeletonHeading = getByRole('heading');
+    expect(skeletonHeading).toBeTruthy();
+
+    // Check citation information rendered correctly
+    const citationCreators = await waitFor(() =>
+      getByText('Bobby; Tommy; Timmy; et al.')
+    );
+    expect(citationCreators).toBeInTheDocument();
+  });
   it('renders Alert error fetching citation data ', async () => {
     server.use(
       // ESGF Citation API (uses dummy link)
@@ -40,6 +70,20 @@ describe('test Citation component', () => {
 
 describe('test CitationInfo component', () => {
   it('returns component', () => {
+    const { getByText } = render(
+      <CitationInfo title="title">children</CitationInfo>
+    );
+
+    // Check title in the document
+    const title = getByText('title', { exact: false });
+    expect(title).toBeInTheDocument();
+
+    // Check children in the document
+    const children = getByText('children');
+    expect(children).toBeInTheDocument();
+  });
+
+  it('returns component with max of 3 creators', () => {
     const { getByText } = render(
       <CitationInfo title="title">children</CitationInfo>
     );

--- a/frontend/src/components/Search/Table.test.tsx
+++ b/frontend/src/components/Search/Table.test.tsx
@@ -59,6 +59,45 @@ it('renders not available for total size and number of files columns when datase
   expect(row).toBeTruthy();
 });
 
+it('renders warning that dataset is retracted', () => {
+  const { getByRole } = render(
+    <Table
+      {...defaultProps}
+      results={[rawSearchResultFixture({ retracted: true })]}
+    />
+  );
+
+  // Check table exists
+  const table = getByRole('table');
+  expect(table).toBeTruthy();
+
+  // Check the dataset title include retracted warning
+  const cell = within(table).getByRole('cell', {
+    name:
+      'foo IMPORTANT! This dataset has been retracted and is no longer avaiable for download.',
+  });
+  expect(cell).toBeTruthy();
+
+  // Get the expandable cell
+  const expandableCell = within(table).getByRole('cell', {
+    name: 'right-circle',
+  });
+  expect(expandableCell).toBeTruthy();
+
+  // Get the right circle icon within the cell and click to expand the row
+  const expandableIcon = within(expandableCell).getByRole('img', {
+    name: 'right-circle',
+  });
+  expect(expandableIcon).toBeTruthy();
+  fireEvent.click(expandableIcon);
+
+  // Get the expandable row that was rendered and click on it
+  const expandableRow = document.querySelector(
+    'tr.ant-table-expanded-row.ant-table-expanded-row-level-1'
+  ) as HTMLElement;
+  expect(expandableRow).toBeTruthy();
+});
+
 it('renders record metadata in an expandable panel', async () => {
   const { getByRole, getByText } = render(<Table {...defaultProps} />);
 

--- a/frontend/src/components/Search/Table.tsx
+++ b/frontend/src/components/Search/Table.tsx
@@ -120,7 +120,9 @@ const Table: React.FC<Props> = ({
       },
       getCheckboxProps: (record: RawSearchResult) => ({
         disabled:
-          canDisableRows && userCart.some((item) => item.id === record.id),
+          canDisableRows &&
+          (userCart.some((item) => item.id === record.id) ||
+            record.retracted === true),
       }),
     },
 
@@ -151,6 +153,7 @@ const Table: React.FC<Props> = ({
           <>
             <Button
               type="primary"
+              disabled={record.retracted === true}
               icon={
                 <PlusOutlined
                   className={topDataRowTargets.getClass('cartAddBtn', 'plus')}
@@ -177,7 +180,20 @@ const Table: React.FC<Props> = ({
       dataIndex: 'title',
       key: 'title',
       width: 400,
-      render: (title: string) => {
+      render: (title: string, record: RawSearchResult) => {
+        if (record && record.retracted) {
+          const msg =
+            'IMPORTANT! This dataset has been retracted and is no longer avaiable for download.';
+          return (
+            <div className={topDataRowTargets.getClass('datasetTitle')}>
+              <p>
+                <span style={{ textDecoration: 'line-through' }}>{title}</span>
+                <br />
+                <span style={{ color: 'red' }}>{msg}</span>
+              </p>
+            </div>
+          );
+        }
         return (
           <div className={topDataRowTargets.getClass('datasetTitle')}>
             {title}
@@ -259,6 +275,7 @@ const Table: React.FC<Props> = ({
             >
               <Form.Item name={formKey}>
                 <Select
+                  disabled={record.retracted === true}
                   className={topDataRowTargets.getClass(
                     'downloadScriptOptions'
                   )}
@@ -280,6 +297,7 @@ const Table: React.FC<Props> = ({
               </Form.Item>
               <Form.Item>
                 <Button
+                  disabled={record.retracted === true}
                   className={topDataRowTargets.getClass('downloadScriptBtn')}
                   type="default"
                   htmlType="submit"

--- a/frontend/src/components/Search/Tabs.tsx
+++ b/frontend/src/components/Search/Tabs.tsx
@@ -100,8 +100,10 @@ const Tabs: React.FC<Props> = ({ record, filenameVars }) => {
     showESDOC || showQualityFlags || showAdditionalLinks;
 
   return (
-    <TabsD>
+    // Disable all tabs excep metadata if the record is retracted
+    <TabsD activeKey={record.retracted === true ? '2' : undefined}>
       <TabsD.TabPane
+        disabled={record.retracted === true}
         tab={
           <div className={innerDataRowTargets.getClass('filesTab')}>Files</div>
         }
@@ -143,6 +145,7 @@ const Tabs: React.FC<Props> = ({ record, filenameVars }) => {
       </TabsD.TabPane>
       {showCitation && (
         <TabsD.TabPane
+          disabled={record.retracted === true}
           tab={
             <div className={innerDataRowTargets.getClass('citationTab')}>
               Citation
@@ -158,6 +161,7 @@ const Tabs: React.FC<Props> = ({ record, filenameVars }) => {
       )}
       {showAdditionalTab && (
         <TabsD.TabPane
+          disabled={record.retracted === true}
           tab={
             <div className={innerDataRowTargets.getClass('additionalTab')}>
               Additional

--- a/frontend/src/components/Search/types.ts
+++ b/frontend/src/components/Search/types.ts
@@ -38,7 +38,8 @@ export type RawSearchResult = {
   further_info_url?: string[] | [];
   number_of_files?: number;
   size?: number;
-  [key: string]: string | string[] | number | undefined;
+  retracted?: boolean;
+  [key: string]: boolean | string | string[] | number | undefined;
 };
 
 export type RawSearchResults = Array<RawSearchResult>;


### PR DESCRIPTION
Added logic and styling so that datasets that are retracted will have a visible indicator as such and prevent users from attempting to download the dataset or add it to their cart.

resolves #362 

- [ x] Local Pre-commit Checks
- [ x] CI/CD Build

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] My changes generate no new warnings
- [ x] If applicable - I have commented my code, particularly in hard-to-understand areas
- [ x] If applicable - I have made corresponding changes to the documentation
- [ x] If applicable - I have added tests that prove my fix is effective or that my feature works
- [ x] If applicable - New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
