### PR TITLE
Updated the facets form

### DIFF
--- a/frontend/src/api/mock/fixtures.ts
+++ b/frontend/src/api/mock/fixtures.ts
@@ -104,6 +104,7 @@ export const parsedFacetsFixture = (
     facet2: [
       ['baz', 2],
       ['fubar', 3],
+      ['very_long_facet_text_name_which_wont_fit', 2],
     ],
     optional: [['none', 8]],
   };

--- a/frontend/src/components/App/App.test.tsx
+++ b/frontend/src/components/App/App.test.tsx
@@ -323,7 +323,7 @@ it('handles applying and removing project facets', async () => {
   expect(facetsForm).toBeTruthy();
 
   // Open top collapse panel
-  const group1Panel = within(facetsComponent).getByRole('tab', {
+  const group1Panel = within(facetsComponent).getByRole('button', {
     name: 'right Group1',
   });
   fireEvent.click(group1Panel);

--- a/frontend/src/components/Facets/FacetsForm.tsx
+++ b/frontend/src/components/Facets/FacetsForm.tsx
@@ -3,7 +3,16 @@ import {
   RightCircleOutlined,
   SearchOutlined,
 } from '@ant-design/icons';
-import { Col, Collapse, DatePicker, Form, Input, Row, Select } from 'antd';
+import {
+  Col,
+  Collapse,
+  DatePicker,
+  Form,
+  Input,
+  Row,
+  Select,
+  Tooltip,
+} from 'antd';
 import moment from 'moment';
 import React from 'react';
 import { leftSidebarTargets } from '../../common/reactJoyrideSteps';
@@ -206,6 +215,11 @@ const FacetsForm: React.FC<Props> = ({
   const facetsByGroup = activeSearchQuery.project.facetsByGroup as {
     [key: string]: string[];
   };
+
+  // Used to control text length of the drop-down items
+  // Tooltip is shown if the length is above this threshold
+  const maxItemLength = 22;
+
   return (
     <div data-testid="facets-form">
       <Form
@@ -215,7 +229,7 @@ const FacetsForm: React.FC<Props> = ({
         }}
       >
         <div style={styles.container}>
-          <Collapse accordion>
+          <Collapse>
             {facetsByGroup &&
               Object.keys(facetsByGroup).map((group) => (
                 <Collapse.Panel
@@ -298,6 +312,29 @@ const FacetsForm: React.FC<Props> = ({
                                       ({variable[1]})
                                     </span>
                                   </StatusToolTip>
+                                );
+                              }
+                              // If the option output name is very long, use a tooltip
+                              const vLength = variable[0].length - 2;
+                              const cLength =
+                                variable[1].toString().length * 1.5 + 2;
+                              if (vLength > maxItemLength - cLength) {
+                                const innerTitle = variable[0].substring(
+                                  0,
+                                  maxItemLength - cLength
+                                );
+                                optionOutput = (
+                                  <Tooltip
+                                    overlayInnerStyle={{
+                                      width: 'max-content',
+                                    }}
+                                    title={variable[0]}
+                                  >
+                                    {innerTitle}...
+                                    <span style={styles.facetCount}>
+                                      ({variable[1]})
+                                    </span>
+                                  </Tooltip>
                                 );
                               }
                               return (

--- a/frontend/src/components/Facets/index.test.tsx
+++ b/frontend/src/components/Facets/index.test.tsx
@@ -82,7 +82,7 @@ it('handles facets form auto-filtering', async () => {
   await waitFor(() => expect(facetsForm).toBeTruthy());
 
   // Open top collapse panel
-  const group1Panel = within(facetsForm).getByRole('tab', {
+  const group1Panel = within(facetsForm).getByRole('button', {
     name: 'right Group1',
   });
   fireEvent.click(group1Panel);
@@ -131,7 +131,7 @@ it('handles facets form submission, including a facet key that is undefined', as
   expect(projectForm).toBeTruthy();
 
   // Open top collapse panel
-  const group1Panel = within(facetsForm).getByRole('tab', {
+  const group1Panel = within(facetsForm).getByRole('button', {
     name: 'right Group1',
   });
   fireEvent.click(group1Panel);
@@ -157,7 +157,7 @@ it('handles facets form submission, including a facet key that is undefined', as
 
   // Open Collapse Panel for  in Collapse component for the facet2 form to render
   // Open additional properties collapse panel
-  const collapse2 = getByRole('tab', {
+  const collapse2 = getByRole('button', {
     name: 'right Group2',
   });
   fireEvent.click(collapse2);


### PR DESCRIPTION
Update to remove the accordion behavior so that the fields don't collapse automatically when selecting a different field. Updated the facet selector items to reduce the text length and add a tooltip if the item is too long for the form.

Fixes # (issue)
#369 