### PR TITLE
Helm chart extra ingress resource for the backend admin interface

### DIFF
--- a/helm/templates/backend/deployment.yaml
+++ b/helm/templates/backend/deployment.yaml
@@ -56,6 +56,13 @@ spec:
             {{- $hosts = append $hosts . }}
           {{- end }}
           value: {{ toJson $hosts | quote }}
+        - name: DJANGO_CSRF_TRUSTED_ORIGINS
+          {{- $uris := list "http://localhost" "http://$(THIS_POD_IP)" }}
+          {{- range .Values.ingress.hosts }}
+            {{- $uri := print "https://" . }}
+            {{- $uris = append $uris $uri }}
+          {{- end }}
+          value: {{ toJson $uris | quote }}
         ports:
         - name: http
           containerPort: {{ .Values.backend.service.port }}

--- a/helm/templates/ingress-admin.yaml
+++ b/helm/templates/ingress-admin.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.ingress.enabled .Values.ingress.admin.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "metagrid.fullname" . }}-admin
+  labels:
+    {{- include "metagrid.labels" . | nindent 4 }}
+  {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ingress.admin.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    {{- range .Values.ingress.hosts }}
+    - {{ . | quote }}
+    {{- end }}
+    secretName: {{ default (printf "%s-ingress-cert" (include "metagrid.fullname" .)) .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+  {{- $prefix := include "metagrid.fullname" . }}
+  {{- range .Values.ingress.hosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - path: /static
+        pathType: {{ $.Values.ingress.pathType }}
+        backend:
+          service:
+            name: {{ $prefix }}-backend
+            port:
+              number: {{ $.Values.backend.service.port }}
+      - path: /{{ $.Values.django.adminUrl }}
+        pathType: {{ $.Values.ingress.pathType }}
+        backend:
+          service:
+            name: {{ $prefix }}-backend
+            port:
+              number: {{ $.Values.backend.service.port }}
+  {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,6 +11,10 @@ ingress:
   className: ""
   labels: {}
   annotations: {}
+  admin:
+    enabled: true
+    # Annotations specific to the admin ingress for e.g. an IP whitelist
+    annotations: {}
 
 # External node status url, used when `nodeStatusBackend.enabled` is false.
 nodeStatusUrl:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,7 +12,7 @@ ingress:
   labels: {}
   annotations: {}
   admin:
-    enabled: true
+    enabled: false
     # Annotations specific to the admin ingress for e.g. an IP whitelist
     annotations: {}
 


### PR DESCRIPTION
## Description

This is to allow access to the Django admin interface without needing go via localhost; useful for a Kubernetes deployment.

When setting `ingress.admin.enabled` to "true" in the Helm chart's values, an extra ingress resource is created with configurable alternative annotations to the main ingress (allowing for adding an IP whitelist to protect access). By default, this value is set to "false" and the admin interface remains inaccessible. So, this change should be compatible with all existing deployments.

Fixes # NA

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Turning `ingress.admin.enabled` on and off to check that the additional ingress resource is created/destroyed appropriately and nothing else about the deployment is affected.

Tested with `django.adminUrl` set to "admin/" (trailing slash is key!).

- [x] Local Pre-commit Checks
- [x] CI/CD Build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] If applicable - I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
