### PR TITLE
Add per-project configurable STAC catalog URLS

### DIFF
--- a/backend/metagrid/api_proxy/tests/test_views.py
+++ b/backend/metagrid/api_proxy/tests/test_views.py
@@ -135,6 +135,122 @@ class TestProxyViewSet(APITestCase):
         assert response.status_code == status.HTTP_200_OK
 
     @responses.activate
+    def test_stac_search_with_custom_url_with_trailing_slash(self):
+        """Test that custom STAC URLs work correctly even with trailing slashes"""
+        url = reverse("do-stac-search")
+        custom_stac_url = "https://custom-stac.example.com/"
+        postdata = {
+            "collections": "CMIP7",
+            "limit": 10,
+            "stacApiUrl": custom_stac_url,
+        }
+        # Mock the custom STAC URL (with trailing slash in postdata, endpoint adds /search)
+        responses.post(custom_stac_url + "search", json={})
+        response = self.client.post(url, postdata, format="json")
+        assert response.status_code == status.HTTP_200_OK
+
+    @responses.activate
+    def test_stac_aggregations(self):
+        """Test STAC aggregations with default settings.STAC_URL"""
+        url = reverse("fetch-stac-aggregations")
+        postdata = {"collections": "CMIP6", "aggregations": ["test_agg"]}
+        # Only run if settings.STAC_URL is set
+        if getattr(settings, "STAC_URL", None):
+            responses.post(settings.STAC_URL + "/aggregate", json={})
+            response = self.client.post(url, postdata, format="json")
+            assert response.status_code == status.HTTP_200_OK
+        else:
+            # If STAC_URL is None, just skip the test
+            import pytest
+
+            pytest.skip("settings.STAC_URL is not set")
+
+    @responses.activate
+    def test_stac_aggregations_with_custom_url(self):
+        """Test STAC aggregations with custom stacApiUrl in request"""
+        url = reverse("fetch-stac-aggregations")
+        custom_stac_url = "https://custom-stac.example.com"
+        postdata = {
+            "collections": "CMIP7",
+            "aggregations": ["test_agg"],
+            "stacApiUrl": custom_stac_url,
+        }
+        # Mock the custom STAC URL
+        responses.post(custom_stac_url + "/aggregate", json={})
+        response = self.client.post(url, postdata, format="json")
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_stac_search_with_invalid_json(self):
+        """Test that invalid JSON in request body returns 400"""
+        url = reverse("do-stac-search")
+        response = self.client.post(
+            url, "invalid json", content_type="application/json"
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_stac_aggregations_with_invalid_json(self):
+        """Test that invalid JSON in aggregations request body returns 400"""
+        url = reverse("fetch-stac-aggregations")
+        response = self.client.post(
+            url, "invalid json", content_type="application/json"
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @responses.activate
+    def test_stac_search_request_exception(self):
+        """Test that network errors during STAC search are handled"""
+        url = reverse("do-stac-search")
+        custom_stac_url = "https://custom-stac.example.com"
+        postdata = {
+            "collections": "CMIP7",
+            "limit": 10,
+            "stacApiUrl": custom_stac_url,
+        }
+        # Mock a failing request
+        responses.post(
+            custom_stac_url + "/search",
+            body=Exception("Network error"),
+        )
+        response = self.client.post(url, postdata, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @responses.activate
+    def test_stac_aggregations_request_exception(self):
+        """Test that network errors during STAC aggregations are handled"""
+        url = reverse("fetch-stac-aggregations")
+        custom_stac_url = "https://custom-stac.example.com"
+        postdata = {
+            "collections": "CMIP7",
+            "aggregations": ["test_agg"],
+            "stacApiUrl": custom_stac_url,
+        }
+        # Mock a failing request
+        responses.post(
+            custom_stac_url + "/aggregate",
+            body=Exception("Network error"),
+        )
+        response = self.client.post(url, postdata, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @responses.activate
+    @override_settings(STAC_URL=None)
+    def test_stac_search_no_stac_url_configured(self):
+        """Test that missing STAC_URL returns 400"""
+        url = reverse("do-stac-search")
+        postdata = {"collections": "CMIP6", "limit": 10}
+        response = self.client.post(url, postdata, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @responses.activate
+    @override_settings(STAC_URL=None)
+    def test_stac_aggregations_no_stac_url_configured(self):
+        """Test that missing STAC_URL returns 400 for aggregations"""
+        url = reverse("fetch-stac-aggregations")
+        postdata = {"collections": "CMIP6", "aggregations": ["test_agg"]}
+        response = self.client.post(url, postdata, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @responses.activate
     def test_citation(self):
         url = reverse("do-citation")
         jo = {

--- a/backend/metagrid/api_proxy/tests/test_views.py
+++ b/backend/metagrid/api_proxy/tests/test_views.py
@@ -121,6 +121,20 @@ class TestProxyViewSet(APITestCase):
             pytest.skip("settings.STAC_URL is not set")
 
     @responses.activate
+    def test_stac_search_with_custom_url(self):
+        url = reverse("do-stac-search")
+        custom_stac_url = "https://custom-stac.example.com"
+        postdata = {
+            "collections": "CMIP7",
+            "limit": 10,
+            "stacApiUrl": custom_stac_url,
+        }
+        # Mock the custom STAC URL
+        responses.post(custom_stac_url + "/search", json={})
+        response = self.client.post(url, postdata, format="json")
+        assert response.status_code == status.HTTP_200_OK
+
+    @responses.activate
     def test_citation(self):
         url = reverse("do-citation")
         jo = {

--- a/backend/metagrid/api_proxy/views.py
+++ b/backend/metagrid/api_proxy/views.py
@@ -86,17 +86,18 @@ def do_search(request):
 def do_stac_search(request):
     print("STAC Search Request:", request.method, request.body)
 
-    if settings.STAC_URL is None:
-        return HttpResponseBadRequest("STAC URL not configured.")
-
     # Check if a custom STAC URL is provided in the request body
     try:
         jo = json.loads(request.body)
         custom_stac_url = jo.pop("stacApiUrl", None)
         stac_url = custom_stac_url if custom_stac_url else settings.STAC_URL
 
+        # Check if we have a STAC URL (either custom or from settings)
+        if stac_url is None:
+            return HttpResponseBadRequest("STAC URL not configured.")
+
         # Strip trailing slash to avoid double slashes
-        if stac_url and stac_url.endswith("/"):
+        if stac_url.endswith("/"):
             stac_url = stac_url.rstrip("/")
 
         # Forward the request to the STAC server (without stacApiUrl field)
@@ -116,17 +117,18 @@ def do_stac_search(request):
 @require_http_methods(["POST"])
 @csrf_exempt
 def fetch_stac_aggregations(request):
-    if settings.STAC_URL is None:
-        return HttpResponseBadRequest("STAC URL not configured.")
-
     # Check if a custom STAC URL is provided in the request body
     try:
         jo = json.loads(request.body)
         custom_stac_url = jo.pop("stacApiUrl", None)
         stac_url = custom_stac_url if custom_stac_url else settings.STAC_URL
 
+        # Check if we have a STAC URL (either custom or from settings)
+        if stac_url is None:
+            return HttpResponseBadRequest("STAC URL not configured.")
+
         # Strip trailing slash to avoid double slashes
-        if stac_url and stac_url.endswith("/"):
+        if stac_url.endswith("/"):
             stac_url = stac_url.rstrip("/")
 
         # Forward the request to the STAC server (without stacApiUrl field)

--- a/backend/metagrid/api_proxy/views.py
+++ b/backend/metagrid/api_proxy/views.py
@@ -84,8 +84,6 @@ def do_search(request):
 @require_http_methods(["POST"])
 @csrf_exempt
 def do_stac_search(request):
-    print("STAC Search Request:", request.method, request.body)
-
     # Check if a custom STAC URL is provided in the request body
     try:
         jo = json.loads(request.body)
@@ -135,10 +133,7 @@ def fetch_stac_aggregations(request):
         try:
             resp = requests.post(stac_url + "/aggregate", json=jo)
         except Exception as e:
-            print("Error fetching STAC aggregations:\n", e)
             return HttpResponseBadRequest(f"Error during POST request: {e}")
-
-        print("STAC Aggregations:", resp.text)
 
         httpresp = HttpResponse(resp.text, content_type="text/json")
         httpresp.status_code = resp.status_code

--- a/backend/metagrid/api_proxy/views.py
+++ b/backend/metagrid/api_proxy/views.py
@@ -89,7 +89,24 @@ def do_stac_search(request):
     if settings.STAC_URL is None:
         return HttpResponseBadRequest("STAC URL not configured.")
 
-    return do_post(request, settings.STAC_URL + "/search")
+    # Check if a custom STAC URL is provided in the request body
+    try:
+        jo = json.loads(request.body)
+        custom_stac_url = jo.pop("stacApiUrl", None)
+        stac_url = custom_stac_url if custom_stac_url else settings.STAC_URL
+
+        # Forward the request to the STAC server (without stacApiUrl field)
+        try:
+            resp = requests.post(stac_url + "/search", json=jo)
+        except Exception as e:
+            return HttpResponseBadRequest(f"Error during POST request: {e}")
+
+        httpresp = HttpResponse(resp.text, content_type="text/json")
+        httpresp.status_code = resp.status_code
+        return httpresp
+
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Invalid JSON in request body.")
 
 
 @require_http_methods(["POST"])
@@ -98,14 +115,27 @@ def fetch_stac_aggregations(request):
     if settings.STAC_URL is None:
         return HttpResponseBadRequest("STAC URL not configured.")
 
+    # Check if a custom STAC URL is provided in the request body
     try:
-        summaries = do_post(request, settings.STAC_URL + "/aggregate")
-    except Exception as e:  # pragma: no cover
-        print("Error fetching STAC aggregations:\n", e)
+        jo = json.loads(request.body)
+        custom_stac_url = jo.pop("stacApiUrl", None)
+        stac_url = custom_stac_url if custom_stac_url else settings.STAC_URL
 
-    print("STAC Aggregations:", summaries)
+        # Forward the request to the STAC server (without stacApiUrl field)
+        try:
+            resp = requests.post(stac_url + "/aggregate", json=jo)
+        except Exception as e:
+            print("Error fetching STAC aggregations:\n", e)
+            return HttpResponseBadRequest(f"Error during POST request: {e}")
 
-    return summaries
+        print("STAC Aggregations:", resp.text)
+
+        httpresp = HttpResponse(resp.text, content_type="text/json")
+        httpresp.status_code = resp.status_code
+        return httpresp
+
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Invalid JSON in request body.")
 
 
 @require_http_methods(["POST"])

--- a/backend/metagrid/api_proxy/views.py
+++ b/backend/metagrid/api_proxy/views.py
@@ -95,6 +95,10 @@ def do_stac_search(request):
         custom_stac_url = jo.pop("stacApiUrl", None)
         stac_url = custom_stac_url if custom_stac_url else settings.STAC_URL
 
+        # Strip trailing slash to avoid double slashes
+        if stac_url and stac_url.endswith("/"):
+            stac_url = stac_url.rstrip("/")
+
         # Forward the request to the STAC server (without stacApiUrl field)
         try:
             resp = requests.post(stac_url + "/search", json=jo)
@@ -120,6 +124,10 @@ def fetch_stac_aggregations(request):
         jo = json.loads(request.body)
         custom_stac_url = jo.pop("stacApiUrl", None)
         stac_url = custom_stac_url if custom_stac_url else settings.STAC_URL
+
+        # Strip trailing slash to avoid double slashes
+        if stac_url and stac_url.endswith("/"):
+            stac_url = stac_url.rstrip("/")
 
         # Forward the request to the STAC server (without stacApiUrl field)
         try:

--- a/frontend/public/changelog/v1.6.2.md
+++ b/frontend/public/changelog/v1.6.2.md
@@ -2,4 +2,5 @@
 
 1. Refactored and updated caching functions to also apply to non-STAC projects, improving search results and pagination performance overall.
 2. Updates to help reduce unnecessary api requests when populating the search tables and U.I. elements.
-3. Minor bug fixes and dependency updates.
+3. Added per-project STAC API URL override capability - projects can now specify a custom `stacApiUrl` in their configuration to use different STAC endpoints.
+4. Minor bug fixes and dependency updates.

--- a/frontend/public/changelog/v1.6.2.md
+++ b/frontend/public/changelog/v1.6.2.md
@@ -3,4 +3,5 @@
 1. Refactored and updated caching functions to also apply to non-STAC projects, improving search results and pagination performance overall.
 2. Updates to help reduce unnecessary api requests when populating the search tables and U.I. elements.
 3. Added per-project STAC API URL override capability - projects can now specify a custom `stacApiUrl` in their configuration to use different STAC endpoints.
-4. Minor bug fixes and dependency updates.
+4. Updated the 'Open as JSON' button to correctly utilize the search filters for both STAC nad non-STAC responses.
+5. Minor bug fixes and dependency updates.

--- a/frontend/public/projects/projects.json
+++ b/frontend/public/projects/projects.json
@@ -1,10 +1,25 @@
 {
   "additionalProjects": [
     {
-      "name": "CMIP7 STAC",
+      "name": "CMIP7 STAC PROD",
       "projectName": "CMIP7",
       "fullName": "Coupled Model Intercomparison Project Phase 7",
-      "stacApiUrl": "",
+      "stacApiUrl": "https://discovery.integration.esgf-west.org",
+      "projectUrl": "https://wcrp-cmip.org/cmip-phases/cmip7/",
+      "facetsByGroup": {
+        "General": ["mip_era"],
+        "Classifications": [
+          "table_id",
+          { "title": "variable_suffix", "facet": "variable_branding_suffix" }
+        ],
+        "Labels": ["area_label", "vertical_label", "temporal_label", "horizontal_label"]
+      }
+    },
+    {
+      "name": "CMIP7 STAC TEST",
+      "projectName": "CMIP7",
+      "fullName": "Coupled Model Intercomparison Project Phase 7",
+      "stacApiUrl": "https://api.stac.esgf.ceda.ac.uk",
       "projectUrl": "https://wcrp-cmip.org/cmip-phases/cmip7/",
       "facetsByGroup": {
         "General": ["mip_era"],
@@ -19,7 +34,7 @@
       "name": "CMIP6 STAC PROD",
       "projectName": "CMIP6",
       "fullName": "Coupled Model Intercomparison Project Phase 6",
-      "stacApiUrl": "https://discovery.west.esgf.io/",
+      "stacApiUrl": "https://discovery.integration.esgf-west.org",
       "projectUrl": "https://wcrp-cmip.org/cmip-phases/cmip6/",
       "facetsByGroup": {
         "General": ["mip_era"],
@@ -31,10 +46,25 @@
       }
     },
     {
-      "name": "CORDEX CMIP6",
+      "name": "CMIP6 STAC TEST",
+      "projectName": "CMIP6",
+      "fullName": "Coupled Model Intercomparison Project Phase 6",
+      "stacApiUrl": "https://api.stac.esgf.ceda.ac.uk",
+      "projectUrl": "https://wcrp-cmip.org/cmip-phases/cmip6/",
+      "facetsByGroup": {
+        "General": ["mip_era"],
+        "Classifications": [
+          "table_id",
+          { "title": "variable_suffix", "facet": "variable_branding_suffix" }
+        ],
+        "Labels": ["area_label", "vertical_label", "temporal_label", "horizontal_label"]
+      }
+    },
+    {
+      "name": "CORDEX CMIP6 PROD",
       "projectName": "CORDEX-CMIP6",
       "fullName": "Coordinated Regional Climate Downscaling Experiment from CMIP6",
-      "stacApiUrl": "https://discovery.west.esgf.io/",
+      "stacApiUrl": "https://discovery.integration.esgf-west.org",
       "projectUrl": "https://cordex.org/",
       "facetsByGroup": {
         "General": ["mip_era"],

--- a/frontend/public/projects/projects.json
+++ b/frontend/public/projects/projects.json
@@ -4,6 +4,7 @@
       "name": "CMIP7 STAC",
       "projectName": "CMIP7",
       "fullName": "Coupled Model Intercomparison Project Phase 7",
+      "stacApiUrl": "",
       "projectUrl": "https://wcrp-cmip.org/cmip-phases/cmip7/",
       "facetsByGroup": {
         "General": ["mip_era"],
@@ -15,9 +16,25 @@
       }
     },
     {
-      "name": "CORDEX-CMIP6",
+      "name": "CMIP6 STAC PROD",
+      "projectName": "CMIP6",
+      "fullName": "Coupled Model Intercomparison Project Phase 6",
+      "stacApiUrl": "https://discovery.west.esgf.io/",
+      "projectUrl": "https://wcrp-cmip.org/cmip-phases/cmip6/",
+      "facetsByGroup": {
+        "General": ["mip_era"],
+        "Classifications": [
+          "table_id",
+          { "title": "variable_suffix", "facet": "variable_branding_suffix" }
+        ],
+        "Labels": ["area_label", "vertical_label", "temporal_label", "horizontal_label"]
+      }
+    },
+    {
+      "name": "CORDEX CMIP6",
       "projectName": "CORDEX-CMIP6",
       "fullName": "Coordinated Regional Climate Downscaling Experiment from CMIP6",
+      "stacApiUrl": "https://discovery.west.esgf.io/",
       "projectUrl": "https://cordex.org/",
       "facetsByGroup": {
         "General": ["mip_era"],

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -190,9 +190,6 @@ export const clearAllMemoizationCaches = (): void => {
  * Sets the expected project name so requests for the old project are ignored
  */
 export const clearStacCaches = (newProjectName?: string): void => {
-  // eslint-disable-next-line no-console
-  console.log('[clearStacCaches] Clearing STAC caches, new project:', newProjectName || 'unknown');
-
   // Set the expected project name
   currentStacProject = newProjectName || null;
 
@@ -912,19 +909,8 @@ export const postSTACSearch = async (
   token?: string,
   stacApiUrl?: string,
 ): Promise<Record<string, unknown>> => {
-  // eslint-disable-next-line no-console
-  console.log('[postSTACSearch] Request for project:', projectName);
-  // eslint-disable-next-line no-console
-  console.log('[postSTACSearch] Current expected project:', currentStacProject);
-
   // Check if this request is for a stale project BEFORE doing anything
   if (currentStacProject !== null && currentStacProject !== projectName) {
-    // eslint-disable-next-line no-console
-    console.log(
-      '[postSTACSearch] ✗ BLOCKING stale request for:',
-      projectName,
-      `(expected: ${currentStacProject})`,
-    );
     // Return a promise that never resolves - it will be abandoned when component re-renders
     // This avoids triggering error handlers in the UI
     return new Promise(() => {
@@ -936,41 +922,19 @@ export const postSTACSearch = async (
   const now = Date.now();
   const cached = stacSearchCache.get(cacheKey);
 
-  // eslint-disable-next-line no-console
-  console.log('[postSTACSearch] FULL Cache key:', cacheKey);
-  // eslint-disable-next-line no-console
-  console.log('[postSTACSearch] Cache has', stacSearchCache.size, 'entries');
-  // eslint-disable-next-line no-console
-  console.log('[postSTACSearch] Cache lookup result:', cached ? 'FOUND' : 'NOT FOUND');
-
   // Return cached result if still valid
   if (cached?.result && cached.timestamp && now - cached.timestamp < STAC_SEARCH_CACHE_TTL) {
-    const age = Math.round((now - cached.timestamp) / 1000);
-    // eslint-disable-next-line no-console
-    console.log(`[postSTACSearch] ✓ Returning CACHED result for: ${projectName} (age: ${age}s)`);
     return Promise.resolve(cached.result);
   }
 
   // Return in-flight promise if already fetching
   if (cached?.promise) {
-    // eslint-disable-next-line no-console
-    console.log('[postSTACSearch] ⏳ Returning IN-FLIGHT promise for:', projectName);
     return cached.promise;
   }
-
-  // eslint-disable-next-line no-console
-  console.log('[postSTACSearch] → Making NEW request for:', projectName);
 
   // Start new fetch and cache the promise
   const promise = postSTACSearchImpl(projectName, limit, filter, q, token, stacApiUrl)
     .then((result) => {
-      // eslint-disable-next-line no-console
-      console.log('[postSTACSearch] ✓ Request completed for:', projectName);
-      // eslint-disable-next-line no-console
-      console.log(
-        '[postSTACSearch] 💾 CACHING result with key:',
-        `${cacheKey.substring(0, 80)}...`,
-      );
       // Cache the result
       stacSearchCache.set(cacheKey, {
         result,
@@ -980,8 +944,6 @@ export const postSTACSearch = async (
       return result;
     })
     .catch((error) => {
-      // eslint-disable-next-line no-console
-      console.error('[postSTACSearch] ✗ Request failed for:', projectName, error);
       // Clear the promise on error so it can be retried
       const entry = stacSearchCache.get(cacheKey);
       if (entry) {
@@ -1045,19 +1007,8 @@ export const fetchSTACAggregations = async (
   filter: { op: string; args: unknown } | undefined,
   stacApiUrl?: string,
 ): Promise<StacAggregations> => {
-  // eslint-disable-next-line no-console
-  console.log('[fetchSTACAggregations] Request for project:', projectName);
-  // eslint-disable-next-line no-console
-  console.log('[fetchSTACAggregations] Current expected project:', currentStacProject);
-
   // Check if this request is for a stale project BEFORE doing anything
   if (currentStacProject !== null && currentStacProject !== projectName) {
-    // eslint-disable-next-line no-console
-    console.log(
-      '[fetchSTACAggregations] ✗ BLOCKING stale request for:',
-      projectName,
-      `(expected: ${currentStacProject})`,
-    );
     // Return a promise that never resolves - it will be abandoned when component re-renders
     // This avoids triggering error handlers in the UI
     return new Promise(() => {
@@ -1074,20 +1025,13 @@ export const fetchSTACAggregations = async (
 
   // Return cached result if available and not expired
   if (cached?.result && cached.timestamp && now - cached.timestamp < STAC_AGGREGATIONS_CACHE_TTL) {
-    // eslint-disable-next-line no-console
-    console.log('[fetchSTACAggregations] ✓ Returning CACHED result for:', projectName);
     return Promise.resolve(cached.result);
   }
 
   // Return in-flight promise if already fetching
   if (cached?.promise) {
-    // eslint-disable-next-line no-console
-    console.log('[fetchSTACAggregations] ⏳ Returning IN-FLIGHT promise for:', projectName);
     return cached.promise;
   }
-
-  // eslint-disable-next-line no-console
-  console.log('[fetchSTACAggregations] → Making NEW request for:', projectName);
 
   // No cache hit, fetch from API
   const aggregationsList = getAggregationsList(projectName);
@@ -1110,8 +1054,6 @@ export const fetchSTACAggregations = async (
   const promise = axios
     .post(`${apiRoutes.esgfAggregationsSTAC.path}`, payload)
     .then((res) => {
-      // eslint-disable-next-line no-console
-      console.log('[fetchSTACAggregations] ✓ Request completed for:', projectName);
       const data = res.data as StacAggregations;
       // Cache the result with timestamp
       stacAggregationsCache.set(cacheKey, {
@@ -1255,25 +1197,10 @@ export const fetchSearchResults = async (
     /* istanbul ignore next -- @preserve */
     const cachedURL = (cachedResults?.cachedURL as string) || '';
 
-    // eslint-disable-next-line no-console
-    console.log('[fetchSearchResults] Checking localStorage cache');
-    // eslint-disable-next-line no-console
-    console.log('[fetchSearchResults] Request URL:', reqUrlStr);
-    // eslint-disable-next-line no-console
-    console.log('[fetchSearchResults] Cached URL:', cachedURL);
-
     // If request URL matches the one in local storage, return the cached results
     if (reqUrlStr === cachedURL) {
-      // eslint-disable-next-line no-console
-      console.log('[fetchSearchResults] ✓ Returning LOCALSTORAGE cached results');
       return cachedResults;
     }
-
-    // eslint-disable-next-line no-console
-    console.log('[fetchSearchResults] ✗ URL mismatch, will fetch fresh data');
-  } else {
-    // eslint-disable-next-line no-console
-    console.log('[fetchSearchResults] Skipping localStorage check (has token)');
   }
 
   const cachedPagination = getCachedPagination();
@@ -1285,13 +1212,6 @@ export const fetchSearchResults = async (
     /* istanbul ignore next -- @preserve */
     const projectName = params.get('project_id') || 'CMIP6';
     const projectHash = params.get('project_hash');
-
-    // eslint-disable-next-line no-console
-    console.log('[fetchSearchResults] URL says project_id:', params.get('project_id'));
-    // eslint-disable-next-line no-console
-    console.log('[fetchSearchResults] URL says project_hash:', projectHash);
-    // eslint-disable-next-line no-console
-    console.log('[fetchSearchResults] → Fetching STAC results for project:', projectName);
 
     return fetchSTACSearchResults(finalUrl, projectName, tokenToUse, projectHash || undefined)
       .then((results) => {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -807,7 +807,11 @@ export const generateSearchURLQuery = (
   );
 
   if (isSTAC) {
-    const url = `${baseRoute}${baseParams}${`project_id=${(project as RawProject).projectName}`}&${textInputsParams}&${activeFacetsParams}`;
+    const rawProject = project as RawProject;
+    const projectHashParam = rawProject.projectHash
+      ? `&project_hash=${rawProject.projectHash}`
+      : '';
+    const url = `${baseRoute}${baseParams}${`project_id=${rawProject.projectName}`}${projectHashParam}&${textInputsParams}&${activeFacetsParams}`;
 
     return url;
   }
@@ -863,6 +867,7 @@ const postSTACSearchImpl = async (
 
 /**
  * Generates a cache key for postSTACSearch based on search parameters
+ * Includes stacApiUrl to differentiate between projects with same projectName but different URLs
  */
 const generateStacSearchCacheKey = (
   projectName: string,
@@ -870,6 +875,7 @@ const generateStacSearchCacheKey = (
   filter: { op: string; args: unknown } | undefined,
   q?: TextInputs,
   token?: string,
+  stacApiUrl?: string,
 ): string => {
   const filterStr = filter ? JSON.stringify(filter) : 'null';
   const qStr = q ? JSON.stringify(q) : 'null';
@@ -880,7 +886,9 @@ const generateStacSearchCacheKey = (
     tokenStr = typeof token === 'object' ? JSON.stringify(token) : token;
   }
 
-  return `${projectName}|${limit}|${filterStr}|${qStr}|${tokenStr}`;
+  const urlStr = stacApiUrl || 'default';
+
+  return `${projectName}|${limit}|${filterStr}|${qStr}|${tokenStr}|${urlStr}`;
 };
 
 /**
@@ -902,6 +910,7 @@ export const postSTACSearch = async (
   filter: { op: string; args: unknown } | undefined = undefined,
   q?: TextInputs,
   token?: string,
+  stacApiUrl?: string,
 ): Promise<Record<string, unknown>> => {
   // eslint-disable-next-line no-console
   console.log('[postSTACSearch] Request for project:', projectName);
@@ -923,7 +932,7 @@ export const postSTACSearch = async (
     });
   }
 
-  const cacheKey = generateStacSearchCacheKey(projectName, limit, filter, q, token);
+  const cacheKey = generateStacSearchCacheKey(projectName, limit, filter, q, token, stacApiUrl);
   const now = Date.now();
   const cached = stacSearchCache.get(cacheKey);
 
@@ -953,7 +962,7 @@ export const postSTACSearch = async (
   console.log('[postSTACSearch] → Making NEW request for:', projectName);
 
   // Start new fetch and cache the promise
-  const promise = postSTACSearchImpl(projectName, limit, filter, q, token)
+  const promise = postSTACSearchImpl(projectName, limit, filter, q, token, stacApiUrl)
     .then((result) => {
       // eslint-disable-next-line no-console
       console.log('[postSTACSearch] ✓ Request completed for:', projectName);
@@ -1010,14 +1019,17 @@ const normalizeReqUrlForCache = (reqUrl: string): string => {
 
 /**
  * Creates a cache key from the relevant parameters
+ * Includes stacApiUrl to differentiate between projects with same projectName but different URLs
  */
 const createAggregationsCacheKey = (
   projectName: string,
   normalizedUrl: string,
   filter: { op: string; args: unknown } | undefined,
+  stacApiUrl?: string,
 ): string => {
   const filterStr = filter ? JSON.stringify(filter) : 'null';
-  return `${projectName}|${normalizedUrl}|${filterStr}`;
+  const urlStr = stacApiUrl || 'default';
+  return `${projectName}|${normalizedUrl}|${filterStr}|${urlStr}`;
 };
 
 /**
@@ -1055,7 +1067,7 @@ export const fetchSTACAggregations = async (
 
   // Create cache key based on non-pagination parameters
   const normalizedUrl = normalizeReqUrlForCache(reqUrl);
-  const cacheKey = createAggregationsCacheKey(projectName, normalizedUrl, filter);
+  const cacheKey = createAggregationsCacheKey(projectName, normalizedUrl, filter, stacApiUrl);
 
   const now = Date.now();
   const cached = stacAggregationsCache.get(cacheKey);
@@ -1127,10 +1139,11 @@ export const fetchSTACSearchResults = async (
   reqUrlStr: string,
   projectName: string,
   token?: string,
+  projectHash?: string,
 ): Promise<SearchResults> => {
   let status = 200;
 
-  const project = getStacProject(projectName);
+  const project = getStacProject(projectName, projectHash);
   const filter = convertSearchParamsIntoStacFilter(reqUrlStr, project);
   const { stacApiUrl } = project;
 
@@ -1162,6 +1175,7 @@ export const fetchSTACSearchResults = async (
     filter,
     textInputs,
     token,
+    stacApiUrl,
   );
 
   const stacResponse: StacSearchResponse = searchResults as StacSearchResponse;
@@ -1270,13 +1284,16 @@ export const fetchSearchResults = async (
     const params = new URLSearchParams(reqUrlStr.split('?')[1]);
     /* istanbul ignore next -- @preserve */
     const projectName = params.get('project_id') || 'CMIP6';
+    const projectHash = params.get('project_hash');
 
     // eslint-disable-next-line no-console
     console.log('[fetchSearchResults] URL says project_id:', params.get('project_id'));
     // eslint-disable-next-line no-console
+    console.log('[fetchSearchResults] URL says project_hash:', projectHash);
+    // eslint-disable-next-line no-console
     console.log('[fetchSearchResults] → Fetching STAC results for project:', projectName);
 
-    return fetchSTACSearchResults(finalUrl, projectName, tokenToUse)
+    return fetchSTACSearchResults(finalUrl, projectName, tokenToUse, projectHash || undefined)
       .then((results) => {
         // Prevent breaking the app if the response is not successful
         if (results.status !== 200) {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -200,15 +200,6 @@ export const clearStacCaches = (newProjectName?: string): void => {
   stacAggregationsCache.clear();
 };
 
-/**
- * Resolves the STAC API URL to use for a project.
- * Returns the project's custom stacApiUrl if set, otherwise undefined
- * (which will cause the caller to use the default proxy routes).
- */
-const getStacApiUrl = (project: RawProject): string | undefined => {
-  return project.stacApiUrl;
-};
-
 export const getCookie = (name: string): null | string => {
   let cookieValue = null;
   const cookieName = name === 'csrftoken' ? 'csrftoken' : `metagrid_${name}`;
@@ -1141,7 +1132,7 @@ export const fetchSTACSearchResults = async (
 
   const project = getStacProject(projectName);
   const filter = convertSearchParamsIntoStacFilter(reqUrlStr, project);
-  const stacApiUrl = getStacApiUrl(project);
+  const { stacApiUrl } = project;
 
   const query = new URLSearchParams(reqUrlStr || '').get('query');
   let textInputs: TextInputs | undefined;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -200,6 +200,15 @@ export const clearStacCaches = (newProjectName?: string): void => {
   stacAggregationsCache.clear();
 };
 
+/**
+ * Resolves the STAC API URL to use for a project.
+ * Returns the project's custom stacApiUrl if set, otherwise undefined
+ * (which will cause the caller to use the default proxy routes).
+ */
+const getStacApiUrl = (project: RawProject): string | undefined => {
+  return project.stacApiUrl;
+};
+
 export const getCookie = (name: string): null | string => {
   let cookieValue = null;
   const cookieName = name === 'csrftoken' ? 'csrftoken' : `metagrid_${name}`;
@@ -826,6 +835,7 @@ const postSTACSearchImpl = async (
   filter: { op: string; args: unknown } | undefined = undefined,
   q?: TextInputs,
   token?: string,
+  stacApiUrl?: string,
 ): Promise<Record<string, unknown>> => {
   const requestBody: {
     collections: string[];
@@ -833,6 +843,7 @@ const postSTACSearchImpl = async (
     filter?: { op: string; args: unknown };
     q?: TextInputs;
     token?: string;
+    stacApiUrl?: string;
   } = {
     collections: [projectName],
     limit,
@@ -846,6 +857,9 @@ const postSTACSearchImpl = async (
   }
   if (token && typeof token === 'string' && token.length > 0) {
     requestBody.token = token;
+  }
+  if (stacApiUrl) {
+    requestBody.stacApiUrl = stacApiUrl;
   }
 
   return axios
@@ -1026,6 +1040,7 @@ export const fetchSTACAggregations = async (
   projectName: string,
   reqUrl: string,
   filter: { op: string; args: unknown } | undefined,
+  stacApiUrl?: string,
 ): Promise<StacAggregations> => {
   // eslint-disable-next-line no-console
   console.log('[fetchSTACAggregations] Request for project:', projectName);
@@ -1074,11 +1089,20 @@ export const fetchSTACAggregations = async (
   // No cache hit, fetch from API
   const aggregationsList = getAggregationsList(projectName);
 
-  const payload = {
+  const payload: {
+    collections: string[];
+    aggregations: string[];
+    filter: { op: string; args: unknown } | undefined;
+    stacApiUrl?: string;
+  } = {
     collections: [projectName],
     aggregations: aggregationsList,
     filter,
   };
+
+  if (stacApiUrl) {
+    payload.stacApiUrl = stacApiUrl;
+  }
 
   const promise = axios
     .post(`${apiRoutes.esgfAggregationsSTAC.path}`, payload)
@@ -1115,7 +1139,9 @@ export const fetchSTACSearchResults = async (
 ): Promise<SearchResults> => {
   let status = 200;
 
-  const filter = convertSearchParamsIntoStacFilter(reqUrlStr, getStacProject(projectName));
+  const project = getStacProject(projectName);
+  const filter = convertSearchParamsIntoStacFilter(reqUrlStr, project);
+  const stacApiUrl = getStacApiUrl(project);
 
   const query = new URLSearchParams(reqUrlStr || '').get('query');
   let textInputs: TextInputs | undefined;
@@ -1125,7 +1151,7 @@ export const fetchSTACSearchResults = async (
     textInputs = query.split(',');
   }
 
-  const aggregations = await fetchSTACAggregations(projectName, reqUrlStr, filter)
+  const aggregations = await fetchSTACAggregations(projectName, reqUrlStr, filter, stacApiUrl)
     .then((response) => {
       // Convert aggregations response into facet data for Metagrid
       const aggregationsToFacets = aggregationsToFacetsData(

--- a/frontend/src/common/STAC.ts
+++ b/frontend/src/common/STAC.ts
@@ -27,7 +27,7 @@ let configuredAdditionalProjects: RawProject[] = [];
 // Creates a RawProject from pk and StacProject data
 function buildStacProject(
   pk: string,
-  { name, fullName, projectUrl, projectName, facetsByGroup }: StacProject,
+  { name, fullName, projectUrl, projectName, facetsByGroup, stacApiUrl }: StacProject,
 ): RawProject {
   const mergedFacetsByGroup: FacetsByGroup = {
     ...STAC_DEFAULT_PROJECT.facetsByGroup,
@@ -50,6 +50,7 @@ function buildStacProject(
     projectName,
     facetsByGroup: mergedFacetsByGroup,
     isSTAC: true,
+    stacApiUrl,
   };
 }
 

--- a/frontend/src/common/STAC.ts
+++ b/frontend/src/common/STAC.ts
@@ -24,6 +24,28 @@ import { STAC_DEFAULT_PROJECT, STAC_PROJECT_LIST, StacProject } from './useProje
 // Global variable to store configured additional projects
 let configuredAdditionalProjects: RawProject[] = [];
 
+/**
+ * Generates a unique hash identifier for a project based on name, projectName, and stacApiUrl.
+ * This ensures we can differentiate between projects with the same projectName but different URLs.
+ */
+export function generateProjectHash(
+  name: string,
+  projectName: string,
+  stacApiUrl?: string,
+): string {
+  const hashInput = `${name}|${projectName}|${stacApiUrl || 'default'}`;
+  // Simple hash function for browser compatibility
+  /* eslint-disable no-plusplus, no-bitwise */
+  let hash = 0;
+  for (let i = 0; i < hashInput.length; i++) {
+    const char = hashInput.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash &= hash; // Convert to 32bit integer
+  }
+  /* eslint-enable no-plusplus, no-bitwise */
+  return Math.abs(hash).toString(36);
+}
+
 // Creates a RawProject from pk and StacProject data
 function buildStacProject(
   pk: string,
@@ -40,6 +62,9 @@ function buildStacProject(
     ];
   });
 
+  // Generate unique hash for this project configuration
+  const projectHash = generateProjectHash(name, projectName, stacApiUrl);
+
   return {
     ...STAC_DEFAULT_PROJECT,
     pk,
@@ -51,6 +76,7 @@ function buildStacProject(
     facetsByGroup: mergedFacetsByGroup,
     isSTAC: true,
     stacApiUrl,
+    projectHash,
   };
 }
 
@@ -85,12 +111,25 @@ export function setConfiguredAdditionalProjects(projects: RawProject[]): void {
 
 /**
  * Gets a STAC project by project name.
+ * If projectHash is provided, looks up by the unique hash identifier first.
+ * Otherwise looks up by 'projectName' field (returns first match).
  * First checks the configured additional projects,
  * then falls back to default STAC_PROJECTS if not found.
  */
-export function getStacProject(projectName: string): RawProject {
+export function getStacProject(projectName: string, projectHash?: string): RawProject {
   // Try to find in configured projects first
   if (configuredAdditionalProjects.length > 0) {
+    // If we have the unique hash, use it for exact match
+    if (projectHash) {
+      const stacProject = configuredAdditionalProjects.find(
+        (project: RawProject) => project.projectHash === projectHash,
+      );
+      if (stacProject) {
+        return stacProject;
+      }
+    }
+
+    // Fall back to projectName lookup (returns first match)
     const stacProject = configuredAdditionalProjects.find(
       (project: RawProject) => (project.projectName || '') === projectName,
     );
@@ -100,6 +139,13 @@ export function getStacProject(projectName: string): RawProject {
   }
 
   // Fall back to default STAC_PROJECTS
+  if (projectHash) {
+    const stacProject = STAC_PROJECTS.find((project) => project.projectHash === projectHash);
+    if (stacProject) {
+      return stacProject;
+    }
+  }
+
   const stacProject = STAC_PROJECTS.find((project) => (project.projectName || '') === projectName);
   return stacProject || STAC_PROJECTS[0];
 }

--- a/frontend/src/common/useProjectsConfig.ts
+++ b/frontend/src/common/useProjectsConfig.ts
@@ -7,6 +7,7 @@ export type StacProject = {
   projectUrl: string;
   projectName: string;
   facetsByGroup: FacetsByGroup;
+  stacApiUrl?: string;
 };
 
 export const STAC_DEFAULT_PROJECT: StacProject = {

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -172,6 +172,7 @@ export const getCurrentAppPage = (): AppPage => {
 export const createSearchRouteURL = (
   url: string,
   stacFilter?: { op: string; args: unknown } | null,
+  stacApiUrl?: string,
 ): string => {
   // Detect if this is a STAC search URL
   const isStacUrl = url.includes('/stac/search');
@@ -211,7 +212,9 @@ export const createSearchRouteURL = (
     newParams.set('q', query);
   }
 
-  return `${window.METAGRID.STAC_URL}/search?${newParams.toString()}`;
+  // Use project-specific STAC URL if provided, otherwise use default
+  const baseUrl = stacApiUrl || window.METAGRID.STAC_URL;
+  return `${baseUrl}/search?${newParams.toString()}`;
 };
 
 /**

--- a/frontend/src/components/Facets/index.tsx
+++ b/frontend/src/components/Facets/index.tsx
@@ -107,9 +107,13 @@ const Facets: React.FC = () => {
             <div>
               <b>Project Url</b>:<br />
               {curProject.projectUrl}
-              <br />
-              <br />
-              <b>STAC Api Url</b>:<br /> https://integration-testing.api.stac.esgf-west.org
+              {curProject.stacApiUrl && (
+                <div>
+                  <br />
+                  <b>STAC Api Url</b>:<br />
+                  {curProject.stacApiUrl}
+                </div>
+              )}
             </div>
           }
         >

--- a/frontend/src/components/Facets/index.tsx
+++ b/frontend/src/components/Facets/index.tsx
@@ -97,7 +97,18 @@ const Facets: React.FC = () => {
         onFinish={handleSubmitProjectForm}
       />
       {curProject && curProject.projectUrl && (
-        <Tooltip title={curProject.projectUrl}>
+        <Tooltip
+          style={{ minWidth: '500px', width: '500px' }}
+          title={
+            <div>
+              <b>Project Url</b>:<br />
+              {curProject.projectUrl}
+              <br />
+              <br />
+              <b>STAC Api Url</b>:<br /> https://integration-testing.api.stac.esgf-west.org
+            </div>
+          }
+        >
           <Button
             href={curProject.projectUrl}
             className={leftSidebarTargets.projectWebsiteBtn.class()}

--- a/frontend/src/components/Facets/types.ts
+++ b/frontend/src/components/Facets/types.ts
@@ -14,6 +14,7 @@ export type RawProject = {
   isSTAC: boolean;
   projectName?: string;
   stacApiUrl?: string;
+  projectHash?: string;
 };
 export type RawProjects = Array<RawProject>;
 

--- a/frontend/src/components/Facets/types.ts
+++ b/frontend/src/components/Facets/types.ts
@@ -13,6 +13,7 @@ export type RawProject = {
   fullName: string;
   isSTAC: boolean;
   projectName?: string;
+  stacApiUrl?: string;
 };
 export type RawProjects = Array<RawProject>;
 

--- a/frontend/src/components/Search/index.tsx
+++ b/frontend/src/components/Search/index.tsx
@@ -1182,9 +1182,7 @@ const Search: React.FC<React.PropsWithChildren<Props>> = ({ onUpdateCart }) => {
                   currentProject.isSTAC
                     ? convertSearchParamsIntoStacFilter(currentRequestURL, currentProject)
                     : null,
-                  'stacApiUrl' in currentProject
-                    ? (currentProject.stacApiUrl as string | undefined)
-                    : undefined,
+                  'stacApiUrl' in currentProject ? currentProject.stacApiUrl : undefined,
                 )}
                 target="_blank"
                 icon={<ExportOutlined />}

--- a/frontend/src/components/Search/index.tsx
+++ b/frontend/src/components/Search/index.tsx
@@ -78,7 +78,11 @@ import {
   TextInputs,
 } from './types';
 import { AuthContext } from '../../contexts/AuthContext';
-import { convertStacToRawSearchResult, stringifyApiRequest } from '../../common/STAC';
+import {
+  convertSearchParamsIntoStacFilter,
+  convertStacToRawSearchResult,
+  stringifyApiRequest,
+} from '../../common/STAC';
 import DownloadModal from '../Downloads/DownloadModal';
 
 const tooltipText = {
@@ -1173,7 +1177,15 @@ const Search: React.FC<React.PropsWithChildren<Props>> = ({ onUpdateCart }) => {
             <Col lg={24} style={{ textAlign: 'center', marginTop: '16px' }}>
               <Button
                 type="default"
-                href={createSearchRouteURL(currentRequestURL)}
+                href={createSearchRouteURL(
+                  currentRequestURL,
+                  currentProject.isSTAC
+                    ? convertSearchParamsIntoStacFilter(currentRequestURL, currentProject)
+                    : null,
+                  'stacApiUrl' in currentProject
+                    ? (currentProject.stacApiUrl as string | undefined)
+                    : undefined,
+                )}
                 target="_blank"
                 icon={<ExportOutlined />}
               >


### PR DESCRIPTION
## Description

Adds the ability to configure the STAC catalog URL to use on a per-project basis for STAC. Also includes fix to the Open as JSON button and updates the project button tooltip to show the project url and the STAC catalog URL.

Fixes #928, #931 

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration.
-->

- [x] Local Pre-commit Checks
- [x] CI/CD Build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] If applicable - I have commented my code, particularly in hard-to-understand areas
- [x] If applicable - I have made corresponding changes to the documentation
- [x] If applicable - I have added tests that prove my fix is effective or that my feature works
- [x] If applicable - New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
